### PR TITLE
style: formatted with vdf-fmt

### DIFF
--- a/Sqooky's .gi/gameinfo.gi
+++ b/Sqooky's .gi/gameinfo.gi
@@ -1,80 +1,80 @@
 //      If you would like to donate as a means of showing thanks I have a kofi.     \\
 //      https://ko-fi.com/sqooky                                                    \\
-//           ...       ....       
-//        ...   ..   ..    ...     
-//       .        . .  o      . 
-//      .          v           . 
-//      . o       ___     o    . 
-//      .     _---   -_      .  
-//     o .   /^        '\     .   
-//        . /   _- /|.  |  o    
-//          |f1/0   @\Y?u\       
+//           ...       ....
+//        ...   ..   ..    ...
+//       .        . .  o      .
+//      .          v           .
+//      . o       ___     o    .
+//      .     _---   -_      .
+//     o .   /^        '\     .
+//        . /   _- /|.  |  o
+//          |f1/0   @\Y?u\
 //      o   /u'\_ v _/ f:j|    o
-//         /!#%|'-_- '\%k*|  
-//     o   |*@/        \_/       
-//         \)&|                  
+//         /!#%|'-_- '\%k*|
+//     o   |*@/        \_/
+//         \)&|
 // OptimizationLock v2.4.1 by Sqooky with help from others <3
 
 // As much as I would love to say I did this alone, I did not. These are the amazing people who deserve as much praise as I, if not more
 //- Sqooky:             I am the primary developer and maintainer of the project, but without everyone else here this project would not be maintained to this degree
 //- JasperP:            My personal hero.
-//- Artemon121:         Made the Citadel cvar unhider, which helped Abdalla fetch cvars and test in-game.  
-//- Boot:               Provided the csm cvars which had a notable performance improvement.  
-//- Brullee:            Removed fake cvars, redundant commands, added cvarlist.md, and reformatted config.  
-//- Dacooder:           Made a wonderful video highlighting me and the config.  
-//- Kaizuchaneru:       While not directly invovled in the deveopment, they tested most cvars.  
-//- Kin:                Did an insane amount of benchmarking unprompted.  
-//- Maihdenless:        Started the original OptimisationLock & its Discord.  
-//- Piggy:              Let me mirror his config.  
+//- Artemon121:         Made the Citadel cvar unhider, which helped Abdalla fetch cvars and test in-game.
+//- Boot:               Provided the csm cvars which had a notable performance improvement.
+//- Brullee:            Removed fake cvars, redundant commands, added cvarlist.md, and reformatted config.
+//- Dacooder:           Made a wonderful video highlighting me and the config.
+//- Kaizuchaneru:       While not directly invovled in the deveopment, they tested most cvars.
+//- Kin:                Did an insane amount of benchmarking unprompted.
+//- Maihdenless:        Started the original OptimisationLock & its Discord.
+//- Piggy:              Let me mirror his config.
 //- Soulx:              Gave me five dollars and told me about spirolactone (fucking sick I love you).
-//- Tamara Mochaccina:  Contributed vindicta scope fix and the fog fix.  
+//- Tamara Mochaccina:  Contributed vindicta scope fix and the fog fix.
 
-"GameInfo"
+GameInfo
 {
-    game                            "citadel"
-    title                           "Citadel"
-    type                            "multiplayer_only"
-    nomodels                        "1"
-    nohimodel                       "1"
-    nocrosshair                     "0"
+    game        "citadel"
+    title       "Citadel"
+    type        "multiplayer_only"
+    nomodels    "1"
+    nohimodel   "1"
+    nocrosshair "0"
     hidden_maps
     {
-        "test_speakers"         1
-        "test_hardware"         1
+        test_speakers "1"
+        test_hardware "1"
     }
-    nodegraph                       "0"
-    perfwizard                      "0"
-    tonemapping                     "0"
-    GameData                        "citadel.fgd"
+    nodegraph   "0"
+    perfwizard  "0"
+    tonemapping "0"
+    GameData    "citadel.fgd"
 
-    DisallowGameInfoConditionals    "0"
-    PGIVersion                      "6E09D3ED5A47F6A97443813F0E00F90BAA435918F82DF0C9B5DA46D27A33D903"
+    DisallowGameInfoConditionals "0"
+    PGIVersion                   "6E09D3ED5A47F6A97443813F0E00F90BAA435918F82DF0C9B5DA46D27A33D903"
 
     Localize
     {
-        DuplicateTokensAssert       "1"
-        DisallowTokenContexts       "1"
+        DuplicateTokensAssert "1"
+        DisallowTokenContexts "1"
     }
 
     SupportedLanguages
     {
-        "brazilian" "3"
-        "czech"     "3"
-        "english"   "3"
-        "french"    "3"
-        "german"    "3"
-        "italian"   "3"
-        "indonesian" "3"
-        "japanese"  "3"
-        "koreana"   "3"
-        "latam"     "3"
-        "polish"    "3"
-        "russian"   "3"
-        "schinese"  "3"
-        "spanish"   "3"
-        "thai"      "3"
-        "turkish"   "3"
-        "ukrainian" "3"
+        brazilian  "3"
+        czech      "3"
+        english    "3"
+        french     "3"
+        german     "3"
+        italian    "3"
+        indonesian "3"
+        japanese   "3"
+        koreana    "3"
+        latam      "3"
+        polish     "3"
+        russian    "3"
+        schinese   "3"
+        spanish    "3"
+        thai       "3"
+        turkish    "3"
+        ukrainian  "3"
     }
 
     FileSystem
@@ -93,99 +93,99 @@
         // Search paths are relative to the exe directory\..\
         //
 
-// Deadlock Mod Manager - Start
+        // Deadlock Mod Manager - Start
 
-		SearchPaths
-        {  
-            Game_Language       citadel_*LANGUAGE*
-            Game                citadel/addons
-            Mod                 citadel
-            Write               citadel          
-            Game                citadel
-            Mod                 core
-            Write               core
-            Game                core        
+        SearchPaths
+        {
+            Game_Language "citadel_*LANGUAGE*"
+            Game          "citadel/addons"
+            Mod           "citadel"
+            Write         "citadel"
+            Game          "citadel"
+            Mod           "core"
+            Write         "core"
+            Game          "core"
         }
-// Deadlock Mod Manager - End
+        // Deadlock Mod Manager - End
     }
 
     MaterialSystem2
     {
         RenderModes
         {
-            game Default
-            game Forward
-            game Deferred
-            game Outline
-            game Depth
-            game FrontDepth
+            game "Default"
+            game "Forward"
+            game "Deferred"
+            game "Outline"
+            game "Depth"
+            game "FrontDepth"
 
-            dev ToolsVis // Visualization modes for all shaders (lighting only, normal maps only, etc.)
-            dev ToolsWireframe // This should use the ToolsVis mode above instead of being its own mode\
+            dev "ToolsVis"       // Visualization modes for all shaders (lighting only, normal maps only, etc.)
+            dev "ToolsWireframe" // This should use the ToolsVis mode above instead of being its own mode\
 
-            tools ToolsUtil // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
+            tools "ToolsUtil" // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
         }
     }
 
     MaterialEditor
     {
-        "DefaultShader"                                "environment_texture_set"
+        DefaultShader "environment_texture_set"
     }
 
     NetworkSystem
     {
         BetaUniverse
         {
-            FakeLag                                    "0"         // I am confident these do as they say      [def: "40"]
-            FakeLoss                                   "0"         //                                          [def: "0.1"]
-            //FakeReorderPct                           "0.05"
-            //FakeReorderDelay                         "10"
-            //FakeJitter                               "low"
+            FakeLag             "0" // I am confident these do as they say      [def: "40"]
+            FakeLoss            "0" //                                          [def: "0.1"]
+            // FakeReorderPct   "0.05"
+            // FakeReorderDelay "10"
+            // FakeJitter       "low"
             // Turning off fake jitter for now while I work on making the CQ totally solid
-            FakeReorderPct                             "0"
-            FakeReorderDelay                           "0"
-            FakeJitter                                 "off"
+            FakeReorderPct   "0"
+            FakeReorderDelay "0"
+            FakeJitter       "off"
         }
 
-        SkipRedundantChangeCallbacks                    "1"
-        UseSerializedEntityPool                         "1"
+        SkipRedundantChangeCallbacks "1"
+        UseSerializedEntityPool      "1"
     }
 
     RenderSystem
     {
-                // Stolen from CS2
-        AllowPartialMipChainImmediateTexLoads  "1"
-        UseHardwareGammaRamp                   "0"         // Fullscreen gamma controlled in postprocessing
-                // End of stolen from CS2
+        // Stolen from CS2
+        AllowPartialMipChainImmediateTexLoads "1"
+        UseHardwareGammaRamp                  "0" // Fullscreen gamma controlled in postprocessing
+        // End of stolen from CS2
 
-        GraphicsPipelineLibrary                         "1"         // This seemed to discard precompiled shaders when set to 0             [def: "1"]
-        IndexBufferPoolSizeMB                           "64"        // Not fully sure, in cs2 this is 64        [def: "32"]
-        LowLatency                                      "1"         //      [def: "1"]
-        MinStreamingPoolSizeMB                          "512"       // In CS2 this is 500, not sure why      [def: "1024"]
-        MinStreamingPoolSizeMBTools                     "2048"      //      [def: "2048"]
-        SwapChainSampleableDepth                        "1"         //      [def: "1"]
-        Use32BitDepthBuffer                             "0"         //      [def: "0"]
-        Use32BitDepthBufferWithoutStencil               "0"         //      [def: "0"]
-        UseReverseDepth                                 "1"         // Also not fully sure.                     [def: "1"]
-        VulkanAdditionalShaderCache                     "vulkan_shader_cache.foz"
-        VulkanDefrag                                    "1"         //      [def: "1"]
-        VulkanMutableSwapchain                          "1"         //      [def: "1"]
-        VulkanOnlyTestProbability                       "0"         // Jasper said that "[when set to 1] this makes users have a 1% chance of using Vulkan" [def: "0"]
-        VulkanOnly_Linux                                "1"         //      [def: "1"]
-        VulkanRequireDescriptorIndexing                 "1"         // Setting this command to zero causes my wayland compositor to crash upon launching the game. I would imagine don't fiddle with it      [def: "1"]
-        VulkanRequireSubgroupWaveOpSupport              "1"         //      [def: "1"]
-        VulkanStagingPMBSizeLimitMB                     "384"       // Jasper (my beloved) said to not mess withthis
-        VulkanSteamAppShaderCache                       "1"         //      [def: "1"]
-        VulkanSteamDownloadedShaderCache                "1"         //      [def: "1"]
-        VulkanSteamShaderCache                          "1"         //      [def: "1"]
+        GraphicsPipelineLibrary            "1"    // This seemed to discard precompiled shaders when set to 0             [def: "1"]
+        IndexBufferPoolSizeMB              "64"   // Not fully sure, in cs2 this is 64        [def: "32"]
+        LowLatency                         "1"    //      [def: "1"]
+        MinStreamingPoolSizeMB             "512"  // In CS2 this is 500, not sure why      [def: "1024"]
+        MinStreamingPoolSizeMBTools        "2048" //      [def: "2048"]
+        SwapChainSampleableDepth           "1"    //      [def: "1"]
+        Use32BitDepthBuffer                "0"    //      [def: "0"]
+        Use32BitDepthBufferWithoutStencil  "0"    //      [def: "0"]
+        UseReverseDepth                    "1"    // Also not fully sure.                     [def: "1"]
+        VulkanAdditionalShaderCache        "vulkan_shader_cache.foz"
+        VulkanDefrag                       "1"   //      [def: "1"]
+        VulkanMutableSwapchain             "1"   //      [def: "1"]
+        VulkanOnlyTestProbability          "0"   // Jasper said that "[when set to 1] this makes users have a 1% chance of using Vulkan" [def: "0"]
+        VulkanOnly_Linux                   "1"   //      [def: "1"]
+        VulkanRequireDescriptorIndexing    "1"   // Setting this command to zero causes my wayland compositor to crash upon launching the game. I would imagine don't fiddle with it      [def: "1"]
+        VulkanRequireSubgroupWaveOpSupport "1"   //      [def: "1"]
+        VulkanStagingPMBSizeLimitMB        "384" // Jasper (my beloved) said to not mess withthis
+        VulkanSteamAppShaderCache          "1"   //      [def: "1"]
+        VulkanSteamDownloadedShaderCache   "1"   //      [def: "1"]
+        VulkanSteamShaderCache             "1"   //      [def: "1"]
 
 
 
-        MinDXLevel "80"
-        MaxPreloadTextureResolution "2"
-        VulkanRequestSM6            "true"
-        //VulkanUseExternalSubpassDependency "true"
-        //VulkanRequireFullGPURayTracing      "true"
+        MinDXLevel                            "80"
+        MaxPreloadTextureResolution           "2"
+        VulkanRequestSM6                      "true"
+        // VulkanUseExternalSubpassDependency "true"
+        // VulkanRequireFullGPURayTracing     "true"
 
 
         AllowPartialMipChainImmediateTexLoads "true"
@@ -195,103 +195,103 @@
 
     NVNGX
     {
-        AppID                                           "103371621"
+        AppID "103371621"
         //DLSSDefaultPreset     // These two values are in the code but I don't know what enabling them does, and I don't have an nvidia gpu to test, alas
         //ReflexLateWarp
-        SupportsDLSS                                    "1"
+        SupportsDLSS "1"
     }
 
     Engine2
     {
-        SinglePlayerAsyncRendering                      "1"         // In the dll, no idea what it does
-        AllowKeyChordBindings                           "1"         //this is for myself actually
-        HasModAppSystems                                "1"
-        Capable64Bit                                    "1"
-        URLName citadel
+        SinglePlayerAsyncRendering "1" // In the dll, no idea what it does
+        AllowKeyChordBindings      "1" //this is for myself actually
+        HasModAppSystems           "1"
+        Capable64Bit               "1"
+        URLName                    "citadel"
         RenderingPipeline
         {
-            SupportsMSAA                                "0"         //                                                      [def: "0"]
-            DistanceField                               "1"         // Setting this to zero crashes the game on vulkan      [def: "1"]
-            AmbientOcclusionProxies                     "0"         // In the dll, no default value
+            SupportsMSAA            "0" //                                                      [def: "0"]
+            DistanceField           "1" // Setting this to zero crashes the game on vulkan      [def: "1"]
+            AmbientOcclusionProxies "0" // In the dll, no default value
         }
-        PauseSinglePlayerOnGameOverlay                  "1"
-        DefensiveConCommands "1"
-        DisableLoadingPlaque "1"
+        PauseSinglePlayerOnGameOverlay "1"
+        DefensiveConCommands           "1"
+        DisableLoadingPlaque           "1"
     }
 
 
 
     SoundSystem
     {
-        SteamAudioEnabled                               "1"
-        WaveDataCacheSizeMB                             "256"
-        UsePlatTime                                     "1"
+        SteamAudioEnabled   "1"
+        WaveDataCacheSizeMB "256"
+        UsePlatTime         "1"
     }
     Sounds
     {
-        HierarchicalEncodingFiles                       "1"
+        HierarchicalEncodingFiles "1"
     }
 
     ToolsEnvironment
     {
-        "Engine"                                        "Source 2"
-        "ToolsDir"                                      "../sdktools"   // NOTE: Default Tools path. This is relative to the mod path.
+        Engine   "Source 2"
+        ToolsDir "../sdktools" // NOTE: Default Tools path. This is relative to the mod path.
     }
 
     pulse
     {
-        "pulse_enabled"                                 "1"
-        strict_fgd_annotations                          "1"
-        client_blackboards                              "1"
+        pulse_enabled          "1"
+        strict_fgd_annotations "1"
+        client_blackboards     "1"
     }
 
     Hammer
     {
-        "CreateRenderClusters"                          "1"
-        "DefaultMinDrawVolumeSize"                      "2048"
-        "DefaultMinTrianglesPerCluster"                 "16384"
-        "DefaultPointEntity"                            "info_player_start"
-        "DefaultSolidEntity"                            "trigger_multiple"
-        "GameFeatureSet"                                "Citadel"
-        "LatticeDeformerEnabled"                        "1"
-        "LoadScriptEntities"                            "0"
-        "NavMarkupEntity"                               "func_nav_markup"
-        "OverlayBoxSize"                                "8"
-        "RenderMode"                                    "ToolsVis"
-        "ShadowAtlasHeight"                             "0"
-        "ShadowAtlasWidth"                              "0"
-        "SteamAudioEnabled"                             "1"
-        "SupportsDisplacementMapping"                   "0"
-        "TileGridBlendDefaultColor"                     "0 255 0"
-        "TileGridSupportsBlendHeight"                   "1"
-        "TileMeshesEnabled"                             "1"
-        "TimeSlicedShadowMapRendering"                  "0"
-        "UseAnalyticGrid"                               "0"
-        "UsesBakedLighting"                             "1"
-        "fgd"                                           "citadel.fgd"   // NOTE: This is relative to the 'game' path.
+        CreateRenderClusters          "1"
+        DefaultMinDrawVolumeSize      "2048"
+        DefaultMinTrianglesPerCluster "16384"
+        DefaultPointEntity            "info_player_start"
+        DefaultSolidEntity            "trigger_multiple"
+        GameFeatureSet                "Citadel"
+        LatticeDeformerEnabled        "1"
+        LoadScriptEntities            "0"
+        NavMarkupEntity               "func_nav_markup"
+        OverlayBoxSize                "8"
+        RenderMode                    "ToolsVis"
+        ShadowAtlasHeight             "0"
+        ShadowAtlasWidth              "0"
+        SteamAudioEnabled             "1"
+        SupportsDisplacementMapping   "0"
+        TileGridBlendDefaultColor     "0 255 0"
+        TileGridSupportsBlendHeight   "1"
+        TileMeshesEnabled             "1"
+        TimeSlicedShadowMapRendering  "0"
+        UseAnalyticGrid               "0"
+        UsesBakedLighting             "1"
+        fgd                           "citadel.fgd" // NOTE: This is relative to the 'game' path.
 
 
-        Thread32First                                   "1"
+        Thread32First "1"
     }
 
     SoundTool
     {
-        "DefaultSoundEventType"                         "src1_3d"
+        DefaultSoundEventType "src1_3d"
 
         SoundEventBaseOptions
         {
-            "Base.Announcer.VO.2d"                      ""
-            "Base.World.VO.Emitter.3d"                  ""
-            "Base.Hero.VO.Ping.2d"                      ""
-            "Base.Hero.VO.2d"                           ""
-            "Base.Hero.VO.3d"                           ""
-            "Base.Hero.VO.Ability.3d"                   ""
-            "Base.Hero.VO.Ultimate.3d"                  ""
-            "Base.Hero.VO.Dash.3d"                      ""
-            "Base.Hero.VO.Effort.3d"                    ""
-            "Base.Hero.VO.Pain.3d"                      ""
-            "Base.Hero.VO.Melee.3d"                     ""
-            "Base.Hero.VO.Death.3d"                     ""
+            Base.Announcer.VO.2d     ""
+            Base.World.VO.Emitter.3d ""
+            Base.Hero.VO.Ping.2d     ""
+            Base.Hero.VO.2d          ""
+            Base.Hero.VO.3d          ""
+            Base.Hero.VO.Ability.3d  ""
+            Base.Hero.VO.Ultimate.3d ""
+            Base.Hero.VO.Dash.3d     ""
+            Base.Hero.VO.Effort.3d   ""
+            Base.Hero.VO.Pain.3d     ""
+            Base.Hero.VO.Melee.3d    ""
+            Base.Hero.VO.Death.3d    ""
         }
     }
 
@@ -307,125 +307,125 @@
         // steps. Additionally this controls which builders are displayed in the hammer build dialog.
         DefaultMapBuilders
         {
-            "bakedlighting"                             "1" // Enable lightmapping during compile time
-            "envmap"                                    "0" // turned off since it currently causes an assert and doesn't work due to some build issue
-            "nav"                                       "1" // Generate nav mesh data
+            bakedlighting "1" // Enable lightmapping during compile time
+            envmap        "0" // turned off since it currently causes an assert and doesn't work due to some build issue
+            nav           "1" // Generate nav mesh data
         }
 
         MeshCompiler
         {
-            OptimizeForMeshlets                         "1"
-            TrianglesPerMeshlet                         "126"  // Maximum valid value currently is 126
-            UseMikkTSpace                               "1"
-            EncodeVertexBuffer                          "1"
-            EncodeVertexBufferVersion                   "1"
-            EncodeVertexBufferLevel                     "3"
-            EncodeIndexBuffer                           "1"
-            SplitDepthStream                            "1"
+            OptimizeForMeshlets       "1"
+            TrianglesPerMeshlet       "126" // Maximum valid value currently is 126
+            UseMikkTSpace             "1"
+            EncodeVertexBuffer        "1"
+            EncodeVertexBufferVersion "1"
+            EncodeVertexBufferLevel   "3"
+            EncodeIndexBuffer         "1"
+            SplitDepthStream          "1"
         }
 
         WorldRendererBuilder
         {
-            VisibilityGuidedMeshClustering              "1"
-            MinimumTrianglesPerClusteredMesh            "8192"
-            MinimumVerticesPerClusteredMesh             "8192"
-            MinimumVolumePerClusteredMesh               "8192"       // ~20x20x20 cube
-            MaxPrecomputedVisClusterMembership          "96"
-            MaxCullingBoundsGroups                      "128"
-            UseAggregateInstances                       "1"
-            AggregateInstancingMeshlets                 "1"
-            BakePropsWithExtraVertexStreams             "1"
+            VisibilityGuidedMeshClustering     "1"
+            MinimumTrianglesPerClusteredMesh   "8192"
+            MinimumVerticesPerClusteredMesh    "8192"
+            MinimumVolumePerClusteredMesh      "8192" // ~20x20x20 cube
+            MaxPrecomputedVisClusterMembership "96"
+            MaxCullingBoundsGroups             "128"
+            UseAggregateInstances              "1"
+            AggregateInstancingMeshlets        "1"
+            BakePropsWithExtraVertexStreams    "1"
         }
 
         BakedLighting
         {
-            Version                                     "4"
-            ImportanceVolumeTransitionRegion            "512"            // distance we transition from high to low resolution charts
+            Version                          "4"
+            ImportanceVolumeTransitionRegion "512" // distance we transition from high to low resolution charts
             LightmapChannels
             {
-                direct_light_shadows                    "1"
-                debug_chart_color                       "1"
-                directional_irradiance_sh2_dc           "1"
+                direct_light_shadows          "1"
+                debug_chart_color             "1"
+                directional_irradiance_sh2_dc "1"
 
                 directional_irradiance_sh2_r
                 {
-                    CompressedFormat                    "DXT1"
+                    CompressedFormat "DXT1"
                 }
 
                 directional_irradiance_sh2_g
                 {
-                    CompressedFormat                    "DXT1"
+                    CompressedFormat "DXT1"
                 }
 
                 directional_irradiance_sh2_b
                 {
-                    CompressedFormat                    "DXT1"
+                    CompressedFormat "DXT1"
                 }
             }
-            LightmapGutterSize                          "2" // For bicubic filtering
-            UseStaticLightProbes                        "0"
-            LPVAtlas                                    "1"
-            BC6HHueShiftFixup                           "0" // Causes more artifacts than it solves atm
-            Repack2                                     "1"
+            LightmapGutterSize   "2" // For bicubic filtering
+            UseStaticLightProbes "0"
+            LPVAtlas             "1"
+            BC6HHueShiftFixup    "0" // Causes more artifacts than it solves atm
+            Repack2              "1"
         }
 
         SteamAudio
         {
             ReverbDefaults
             {
-                GridSpacing                             "3.0"
-                HeightAboveFloor                        "1.5"
-                RebakeOption                            "0"                     // 0: cleanup, 1: manual, 2: auto
-                NumRays                                 "32768"
-                NumBounces                              "64"
-                IRDuration                              "1.0"
-                AmbisonicsOrder                         "1"
+                GridSpacing      "3.0"
+                HeightAboveFloor "1.5"
+                RebakeOption     "0" // 0: cleanup, 1: manual, 2: auto
+                NumRays          "32768"
+                NumBounces       "64"
+                IRDuration       "1.0"
+                AmbisonicsOrder  "1"
             }
             PathingDefaults
             {
-                GridSpacing                             "3.0"
-                HeightAboveFloor                        "1.5"
-                RebakeOption                            "0"                     // 0: cleanup, 1: manual, 2: auto
-                NumVisSamples                           "1"
-                ProbeVisRadius                          "0"
-                ProbeVisThreshold                       "0.1"
-                ProbeVisPathRange                       "1000.0"
+                GridSpacing       "3.0"
+                HeightAboveFloor  "1.5"
+                RebakeOption      "0" // 0: cleanup, 1: manual, 2: auto
+                NumVisSamples     "1"
+                ProbeVisRadius    "0"
+                ProbeVisThreshold "0.1"
+                ProbeVisPathRange "1000.0"
             }
         }
         SoundStackScripts
         {
-            CompileStacksStrict                         "1"
+            CompileStacksStrict "1"
         }
         VisBuilder
         {
-            MaxVisClusters                              "4096"
-            PreMergeOpenSpaceDistanceThreshold          "128.0"
-            PreMergeOpenSpaceMaxDimension               "2048.0"
-            PreMergeOpenSpaceMaxRatio                   "8.0"
-            PreMergeSmallRegionsSizeThreshold           "20.0"
+            MaxVisClusters                     "4096"
+            PreMergeOpenSpaceDistanceThreshold "128.0"
+            PreMergeOpenSpaceMaxDimension      "2048.0"
+            PreMergeOpenSpaceMaxRatio          "8.0"
+            PreMergeSmallRegionsSizeThreshold  "20.0"
         }
 
         VDataLocalization
         {
-            GameOutputPath                              "resource/localization/citadel_vdata"
-            TokenPrefix                                 "Citadel_VData_"
+            GameOutputPath "resource/localization/citadel_vdata"
+            TokenPrefix    "Citadel_VData_"
         }
 
         TextureCompiler
         {
-            //Compressor                                "lz4"
-            //CompressMipsOnDisk                        "1"
-            //CompressMinRatio                          "95"
-            AllowNP2Textures                            "1"
-            AllowPanoramaMipGeneration                  "1"
-            //PublicToolsDefaultMaxRes                  "2048"
+            // Compressor               "lz4"
+            // CompressMipsOnDisk       "1"
+            // CompressMinRatio         "95"
+            AllowNP2Textures            "1"
+            AllowPanoramaMipGeneration  "1"
+            // PublicToolsDefaultMaxRes "2048"
         }
     }
 
     Source1Import
     {
         // this is just copied from the left4dead3 gameinfo.gi
-        "forcevtxfileupconvert"                         "1"
+        forcevtxfileupconvert "1"
     }
 
 
@@ -435,25 +435,25 @@
 
 
         // Build cubemaps into a cube array instead of individual cubemaps.
-        BindlessSceneObjectDesc                         "CitadelBindlessDesc"
-        EnvironmentMapCacheSizeTools                    "300"           // Not sure what this does yet                                                                         [def: "300"]
-        EnvironmentMapColorSpace                        "linear"        // Colorspace. Options should be gamma or linear.                                                      [def: "linear"]
-        EnvironmentMapFaceSize                          "256"          //                                                                                                      [def: "256"]
-        EnvironmentMapFormat                            "BC6H"          // These values don't seem to be able to be changed but this should change the texture format          [def: "BC6H"]
-        EnvironmentMapMipProcessor                      "GGXCubeMapBlur"
-        EnvironmentMapPreviewFormat                     "BC6H"          // ^                                                                                                   [def: "BC6H"]
-        EnvironmentMapRenderSize                        "1024"          // There does not seem to be any downside to messing with this value so it is currently in experimentation. [def: "1024"]
-        EnvironmentMapUseCubeArray                      "1"             // I don't know why disabling this would cause any problems
-        EnvironmentMaps                                 "1"             //                                                                                                      [def: "1"]
-        GrassCastsShadows                               "0"
+        BindlessSceneObjectDesc      "CitadelBindlessDesc"
+        EnvironmentMapCacheSizeTools "300"    // Not sure what this does yet                                                                         [def: "300"]
+        EnvironmentMapColorSpace     "linear" // Colorspace. Options should be gamma or linear.                                                      [def: "linear"]
+        EnvironmentMapFaceSize       "256"    //                                                                                                      [def: "256"]
+        EnvironmentMapFormat         "BC6H"   // These values don't seem to be able to be changed but this should change the texture format          [def: "BC6H"]
+        EnvironmentMapMipProcessor   "GGXCubeMapBlur"
+        EnvironmentMapPreviewFormat  "BC6H" // ^                                                                                                   [def: "BC6H"]
+        EnvironmentMapRenderSize     "1024" // There does not seem to be any downside to messing with this value so it is currently in experimentation. [def: "1024"]
+        EnvironmentMapUseCubeArray   "1"    // I don't know why disabling this would cause any problems
+        EnvironmentMaps              "1"    //                                                                                                      [def: "1"]
+        GrassCastsShadows            "0"
 
         // Stolen from a 2015 gameinfo.gi
-        EnvironmentMapCacheSize                         "16"
+        EnvironmentMapCacheSize "16"
 
         // These are stolen from CS2
-        LPVEdgeBlending                                 "0"             // Don't apply the edge fade distance to LPV bounds, we don't blend LPVs in CS2 shaders
+        LPVEdgeBlending "0" // Don't apply the edge fade distance to LPV bounds, we don't blend LPVs in CS2 shaders
 
-        //EnvironmentMapPreviewFormat                   "RGBA16161616F" // This is from CS2 where it is also commented out. I would imagine setting it enables HDR of some format considering this is the integer HDR format, but I do not have an HDR monitor to test
+        // EnvironmentMapPreviewFormat "RGBA16161616F" // This is from CS2 where it is also commented out. I would imagine setting it enables HDR of some format considering this is the integer HDR format, but I do not have an HDR monitor to test
 
     }
 
@@ -461,651 +461,651 @@
     {
 
 
-        HairShading                                     "false"
-        //MeshletBufferCPUSlotCount                       "0"
-        ParticleBufferSize                              "256"
-        //RenderMeshlets                                  "1"
+        HairShading                  "false"
+        // MeshletBufferCPUSlotCount "0"
+        ParticleBufferSize           "256"
+        // RenderMeshlets            "1"
 
 
-        CMTAtlasHeight                                  "512"
-        CMTAtlasWidth                                   "512"
-        CSMCascadeResolution                            "0"             // [def: "2048"]
-        CharacterDecals                                 "0"
-        CubemapFog                                      "0"             // [def: "1"]
-        DefaultShadowTextureHeight                      "0"             // [def: "6144"]
-        DefaultShadowTextureWidth                       "0"             // [def: "6144"]
+        CMTAtlasHeight             "512"
+        CMTAtlasWidth              "512"
+        CSMCascadeResolution       "0" // [def: "2048"]
+        CharacterDecals            "0"
+        CubemapFog                 "0" // [def: "1"]
+        DefaultShadowTextureHeight "0" // [def: "6144"]
+        DefaultShadowTextureWidth  "0" // [def: "6144"]
         // Temp till I can add support in citadel shaders
-        DisableLateAllocatedTransformBuffer             "1"             // [def: "1"]
-        DynamicShadowResolution                         "1"             // [def: "1"]
-        FogCachedShadowAtlasHeight                      "0"             // [def: "2048"]
-        FogCachedShadowAtlasWidth                       "0"             // [def: "2048"]
-        FogCachedShadowTileSize                         "0"             // [def: "128"]
-        FrameBufferCopyFormat                           "R11G11B10F"    // [def: "R11G11B10F"]
-        GpuLightBinner                                  "1"             // [def: "1"]
-        GpuLightBinnerSunLightFastPath                  "1"             // [def: "1"]
-        GpuLightBinnerSupportViewModelCascade           "1"
-        HDRFrameBuffer                                  "0"
-        LayerBatchThresholdFullsort                     "80"           // [def: "20"]
-        MinimumLateAllocatedVertexCacheBufferSizeMB     "64"            // [def: "64"]
-        NonTexturedGradientFog                          "0"             // [def: "1"]
-        SunLightManagerCount                            "0"             // [def: "0"]
-        SunLightManagerCountTools                       "0"             // [def: "0"]
-        SunLightMaxCascadeSize                          "2"             // [def: "4"]
-        SunLightShadowRenderMode                        "Depth"         // [def: "Depth"]
-        SupportsInstancedFade                           "1"
-        Tonemapping                                     "0"             // [def: "0"]
-        TransformTextureRowCount                        "1024"          // [def: "1024"]
-        TransformTextureRowCountToolsMode               "6144"          // [def: "6144"]
-        VolumetricFog                                   "0"             // [def: "1"]
+        DisableLateAllocatedTransformBuffer         "1"          // [def: "1"]
+        DynamicShadowResolution                     "1"          // [def: "1"]
+        FogCachedShadowAtlasHeight                  "0"          // [def: "2048"]
+        FogCachedShadowAtlasWidth                   "0"          // [def: "2048"]
+        FogCachedShadowTileSize                     "0"          // [def: "128"]
+        FrameBufferCopyFormat                       "R11G11B10F" // [def: "R11G11B10F"]
+        GpuLightBinner                              "1"          // [def: "1"]
+        GpuLightBinnerSunLightFastPath              "1"          // [def: "1"]
+        GpuLightBinnerSupportViewModelCascade       "1"
+        HDRFrameBuffer                              "0"
+        LayerBatchThresholdFullsort                 "80"    // [def: "20"]
+        MinimumLateAllocatedVertexCacheBufferSizeMB "64"    // [def: "64"]
+        NonTexturedGradientFog                      "0"     // [def: "1"]
+        SunLightManagerCount                        "0"     // [def: "0"]
+        SunLightManagerCountTools                   "0"     // [def: "0"]
+        SunLightMaxCascadeSize                      "2"     // [def: "4"]
+        SunLightShadowRenderMode                    "Depth" // [def: "Depth"]
+        SupportsInstancedFade                       "1"
+        Tonemapping                                 "0"    // [def: "0"]
+        TransformTextureRowCount                    "1024" // [def: "1024"]
+        TransformTextureRowCountToolsMode           "6144" // [def: "6144"]
+        VolumetricFog                               "0"    // [def: "1"]
 
         // Stolen from CS2
-        GpuLightBinnerBinEnvMaps                        "1"
-        GpuLightBinnerBinLPVs                           "1"
+        GpuLightBinnerBinEnvMaps "1"
+        GpuLightBinnerBinLPVs    "1"
 
-        LightCookieAllocGranularity                     "1"
-        LightCookieMinAllocSize                         "0"
-        DisableShadowFullSort                           "1"
-        SparseShadowTrees                               "1" // enable this to experiment with Sparse Shadow Trees as a drop in replacement for static geo shadow rendering into cascades
-        PointLightShadowsEnabled                        "1"
+        LightCookieAllocGranularity "1"
+        LightCookieMinAllocSize     "0"
+        DisableShadowFullSort       "1"
+        SparseShadowTrees           "1" // enable this to experiment with Sparse Shadow Trees as a drop in replacement for static geo shadow rendering into cascades
+        PointLightShadowsEnabled    "1"
 
 
         WellKnownLightCookies
         {
-            "blank"                                     "materials/effects/lightcookies/blank.vtex"
-            "flashlight"                                "materials/effects/lightcookies/flashlight.vtex"
+            blank      "materials/effects/lightcookies/blank.vtex"
+            flashlight "materials/effects/lightcookies/flashlight.vtex"
         }
 
-        ComputeShaderSkinning                           "1"
+        ComputeShaderSkinning "1"
     }
 
     NavSystem
     {
-        "NavTileSize" "128.0"
-        "NavCellSize" "1.5"
-        "NavCellHeight" "2.0"
+        NavTileSize   "128.0"
+        NavCellSize   "1.5"
+        NavCellHeight "2.0"
 
         // Hull definitions live in scripts/nav_hulls.vdata
         // Preset definitions live in scripts/nav_hulls_presets.vdata
-        "NavHullsPreset" "default"
+        NavHullsPreset "default"
 
-        "NavRegionMinSize" "8"
-        "NavRegionMergeSize" "20"
-        "NavEdgeMaxLen" "1200"
-        "NavEdgeMaxError" "51.0"
-        "NavVertsPerPoly" "4"
-        "NavDetailSampleDistance" "120.0"
-        "NavDetailSampleMaxError" "2.0"
-        "NavSmallAreaOnEdgeRemovalSize" "81.0"
+        NavRegionMinSize              "8"
+        NavRegionMergeSize            "20"
+        NavEdgeMaxLen                 "1200"
+        NavEdgeMaxError               "51.0"
+        NavVertsPerPoly               "4"
+        NavDetailSampleDistance       "120.0"
+        NavDetailSampleMaxError       "2.0"
+        NavSmallAreaOnEdgeRemovalSize "81.0"
     }
 
     AnimationSystem
     {
-        "DisableServerInterpCompensation"   "1"
-        "DisableAnimationScript"    "1"
-        "ServerPoseRecipeHistorySize"   "60"
-        "ClientPoseRecipeHistorySize"   "60"
+        DisableServerInterpCompensation "1"
+        DisableAnimationScript          "1"
+        ServerPoseRecipeHistorySize     "60"
+        ClientPoseRecipeHistorySize     "60"
 
     }
 
     ModelDoc
     {
-        "models_gamedata"           "models_gamedata.fgd"
-        "features"                  "animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
+        models_gamedata "models_gamedata.fgd"
+        features        "animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
     }
 
     Particles
     {
-        "EnableParticleShaderFeatureBranching"  "1"
-        "Float16HDRBackBuffer" "1"
-        "PET_SupportFadingOpaqueModels" "1"
-        "Features" "non_homogenous_forward_layer_only"
-        ParticlesFoggedByDefault                "0"
-        PerVertexLighting                       "0"
-        GpuImplicitRendererManifest             "1"
-        "EnableMixedResolution" "1"
+        EnableParticleShaderFeatureBranching "1"
+        Float16HDRBackBuffer                 "1"
+        PET_SupportFadingOpaqueModels        "1"
+        Features                             "non_homogenous_forward_layer_only"
+        ParticlesFoggedByDefault             "0"
+        PerVertexLighting                    "0"
+        GpuImplicitRendererManifest          "1"
+        EnableMixedResolution                "1"
     }
 
     ConVars
     {
 
-//      If you would like to donate as a means of showing thanks I have a kofi.     \\
-//      https://ko-fi.com/sqooky                                                    \\
+        //      If you would like to donate as a means of showing thanks I have a kofi.     \\
+        //      https://ko-fi.com/sqooky                                                    \\
 
-// -------- Performance Config! Sqooky's.gi / OptimizationLock -- ver. 2.4.1 -------- \\
-// The github is here https://github.com/Sqooky/OptimizationLock  \\
-// In-Depth Tutorial: https://www.youtube.com/watch?v=zC3wBYY98vU \\
-// The gamebanana:https://gamebanana.com/mods/656341 (it's usually behind, please check the github) \\
-
-
-// ================ Preferences ================
-// --- 0. IMPORTANT ---
-r_particle_max_size_cull                    "999"           //                                                                  [def: "1200"]
-// Particle systems larger than this in every dimension skip culling to save CPU.  They will be drawn anyway 
-// So particle culling is handled by the CPU in deadlock, if you have GPU overhead to spare, consider lowering this value. 
-steam_inputhandler_enabled                  "true"             // This disables controller support when set to false. Setting to false should improve performance if you're not on a steam deck, but some people are, and I don't want an influx of "why no work with controller"  [def: "true"]
-
-// --- 1. Outlines ---
-citadel_unit_status_allies_see_thru_walls   "true"          // Do you want to see allied player outlines through walls          [def: "true"]
-citadel_boss_glow_disabled                  "1"             // Disables boss and walker glow/highlight effect.                  [def: "0]
-citadel_damage_offscreen_indicator_disabled "true"          // The little trooper portraits that show up behind walls.          [def: "true"]
-citadel_player_glow_disabled                "0"             // Disables player glow/highlight effect when pinged.               [def: "0"]
-citadel_trooper_glow_disabled               "1"             // 1 = Disable friendly/enemy minion glow.                          [def: "0"]
-citadel_unit_status_allies_see_thru_walls_max_distance "40" // How far to make allied players' unit status show through walls.  [def: "0"] (0 means no limit)
-//citadel_unit_status_dpi                   "6"             // This increases the size of the health bar. Unfortunately I think this lowers performance. A shame. [def: "5"]
-
-// --- 2. Field of View ---
-// These commands both affect fov but do so in different ways. citadel_camera_hero_fov changes the field of view using typical degrees but doesn't modify the punch zoom in. This means that if you have a high fov value the zoom in can be disorienting.
-//citadel_camera_hero_fov                     "106"           // The field of view angle of the camera when following a hero.     [def: "90"]
-r_aspectratio                               "2.80"          // This command is commented out, represented by the // at the beginning of the line. Editing it will not do anything. To mess with it remove the //
-// r_aspectratio changes the zoom of the camera which in turn doesn't make the punch zoom in as jarring, but the command is not as intuitive to set precisely
-// 1.75=80fov | 2.15=90fov | 2.49=100fov (every .15 interval = 5 fov). 
-
-// --- 3. HUD ---
-citadel_unit_status_delta_decay_rate        "2"             // how quickly the yellow to indicate damage fades from the health bar. [def: "3"]
-//citadel_hud_objective_health_debug_show_midboss "true"      // This makes midboss' health bar visible whenever it's able to be rendered. I like it, you might not [def: "false"]
-//citadel_unit_status_use_v2                "0"             // Set to 1 to enable the new health bar that allows you to  see enemy stamina. [def: "0"]
-//citadel_unit_status_use_v2_for_nonplayers "0"             // Set to 1 to enable the new health bar but for troopers, objs, and camps.     [def: "0"]
-citadel_crosshair_hit_marker_duration       "0.00001"       // Removes the hitmarker when shooting people.                      [def: "0.1"]
-citadel_damage_report_enable                "1"             // Enables/Disables incoming/outgoing damage tab (tuning this off is very questionable but okay). [def: "1"]
-citadel_damage_text_batching_window_ability "1000"          // How long to wait until batching damage text.             
-citadel_hideout_ball_show_juggle_count      "1"             // Shows a fun juggle count minigame for hideout ball.              [def: "0"]
-citadel_hideout_ball_show_juggle_fx         "1"             // Shows juggle visual FX for hideout ball minigame.                [def: "0"]
-citadel_hud_objective_health_enabled        "2"             // 0=Off, 1=Shrines, 2=T1/T2, 3=Barracks.                           [def: "2"]
-citadel_unit_status_use_new                 "1"             // This uses new Health Bar, to use old Health Bar change "true" to "false".    [def: "0"]
-citadel_show_chat_wheel_angle_threshold     "0"             // (degrees) Increase this to change how much you have to move your camera angle to make the Chat Wheel instantly visible while holding Ping. [def: "16"]
-
-// --- 4. Lighting & Shadows ---
-lb_enable_baked_shadows                     "0"             // *Disables baked shadows (game looks bright if this is on while stationary lights = 1). [def: "1"]
-lb_enable_dynamic_lights                    "1"             // *Disables dynamic lights eg. walker, shop, tp, character abilities etc. (hero silhouettes go dark in menus as a side effect) [def: "1"]
-lb_enable_stationary_lights                 "0"             // *Disables stationary lights (map looks flatter but more performant).         [def: "1"]
-
-// --- 5. Skybox Rendering ---
-r_draw3dskybox                              "0"             //  Enables drawing the 3D skybox layer (distant geometry).         [def: "1"]
-
-// --- 6. FPS Caps & Minimized Throttling ---
-engine_low_latency_sleep_after_client_tick  "true"          // Sleeps strategically after client tick to reduce latency/stutter (low-latency pacing). [def: "false"]
-engine_no_focus_sleep                       "20"            // Milliseconds the engine sleeps per frame when unfocused (0 = no sleep, not recommended for low-end PC). [def: "20"]
-fps_max                                     "0"             // Max FPS while in game, limit fps to your monitor refresh rate. [def: "400"]
-panorama_max_fps                            "30"            // Menu FPS.                                                        [def: "120"]
-panorama_max_overlay_fps                    "30"            // Fps In the settings/esc menu.                                    [def: "60"]
-
-// --- 7. Object Culling ---
-r_size_cull_threshold                       "0.9"           // *Culls small objects sooner based on screen size threshold (higher = more culling). [def: "0.8"]
-
-// --- 8. Camera Tweaks ---
-
-//citadel_camera_listening_offset           "-1"            // To be completely honest I have no idea but I want to test this.  [def: "0"]
-citadel_camera_soft_collision_angle         "360"           //                                                                  [def: "75"]
-r_citadel_clip_sphere_min_opacity           "0"             // Removes the blur from the pinhole camera                         [def: "40"]
-//r_citadel_clip_sphere_skin                "0.01"          //                                                                  [def: "0.01"]
-//r_citadel_clip_sphere_cone_angle          "40"            //                                                                  [def: "40"]
-//r_citadel_clip_sphere_distance_max        "75"            //                                                                  [def: "75"]
-// These are various commands for messing with the pinhole camera. I don't fully understand them and they can be ignored for now.
-
-//citadel_camera_hard_trace_radius          "32"            // The radius of the cylinder to trace for hard camera occlusion. Based on reading the cvars docs I assume this is like the bounding box of the camera [def: "16"]
-//citadel_fibonnaci_sphere_trace_los_max    "160"           // How big to cap the size of the sphere when checking for really large explosion/effects [def: "160"]
-
-// Uncommenting these cvars will make it so that you can look above/behind yourself. It's kinda awesome but reverses your movement input and could make some people motion sick.
-//citadel_camera_pitch_max                    "160"           // The maximum pitch angle allowed on the camera.                 [def: "89"]
-//citadel_camera_pitch_min                    "-160"          // The minimum pitch angle allowed on the camera.                 [def: "-89"]
-
-// --- 9. Texture Quality ---
-r_texture_budget_threshold                  "0.7"           // Reduce texture memory pool size when this percentage of the budget is full. [def: "0.8"]
-r_texture_budget_update_period              "0.5"           // Time (in seconds) between updating texture memory budget.        [def: "0.1"]
-r_texture_stream_mip_bias                   "3"             // Worth adjusting, practically how good your textures will look.   [def: "1"]
-r_texturefilteringquality                   "3"             // Texture filtering, has very low fps impact. 0: Bilinear, 1: Trilinear, 2: Aniso 2x, 3: Aniso 4x, 4: Aniso 8x, 5: Aniso 16x
-
-// --- 10. Render Distance ---
-r_farz                                      "8192"          // This controls the far clipping plane, ie building/player popin   [def: "-1"]
-r_mapextents                                "8192"          // Far clipping plane, this will make buildings pop in and out      [def: "16384"] damn that's an oddly specific number
-
-// ================ IMPORTANT ================ 
-thread_pool_option                      "-1"     // If I understand correctly, this should be how threads are handled relative to the game, but there isn't a clear indication of what changing it even does. For now I have it at -1 which is the default, but your mileage may vary. [def: "-1"]
-// 1 gives "GlobalThreadPoolMode" "efficiency"
-// 2 removes it from boot.vcfg
-// 3 gives "GlobalThreadPoolMode" "undifferentiated"
-// 4 gives "GlobalThreadPoolMode" "auto_threads"
-// 5 removes it from boot.vcfg
-// 6 gives "GlobalThreadPoolMode" ""max_threads"
-// 7-10 removes it from boot.vcfg
-
-// -1 Default
-// -2 removes it from boot.vcfg
+        // -------- Performance Config! Sqooky's.gi / OptimizationLock -- ver. 2.4.1 -------- \\
+        // The github is here https://github.com/Sqooky/OptimizationLock  \\
+        // In-Depth Tutorial: https://www.youtube.com/watch?v=zC3wBYY98vU \\
+        // The gamebanana:https://gamebanana.com/mods/656341 (it's usually behind, please check the github) \\
 
 
-// ================= UI ================
-citadel_damage_text_show_effectiveness      "0"             // Shows extra “effectiveness” info in damage text (e.g., resist/weakness style feedback). [def: "0"]
-closecaption                                "false"         // I assume this does what it says on the tin                       [def: "false"]
-panorama_allow_transitions                  "false"         // Turns off UI anim (shop,etc)                                     [def: "1"]
-panorama_disable_blur                       "1"             // Disables UI blur effects in the UI.                              [def: "0"]
-panorama_disable_box_shadow                 "1"             // Disables UI box shadows in the UI (less GPU/UI cost).            [def: "0"]
-panorama_temp_comp_layer_min_dimension      "128"           // Based on the name I'm implied to believe this is the minimum size for panorama compositing, ie blur, rounded corners, etc. [def: "512"]
-r_citadel_enable_pano_world_blur            "true"
-r_dashboard_render_quality                  "0"             // Sets dashboard/UI render quality (lower = cheaper UI rendering). [def: "1"]
+        // ================ Preferences ================
+        // --- 0. IMPORTANT ---
+        r_particle_max_size_cull "999" //                                                                  [def: "1200"]
+        // Particle systems larger than this in every dimension skip culling to save CPU.  They will be drawn anyway
+        // So particle culling is handled by the CPU in deadlock, if you have GPU overhead to spare, consider lowering this value.
+        steam_inputhandler_enabled "true" // This disables controller support when set to false. Setting to false should improve performance if you're not on a steam deck, but some people are, and I don't want an influx of "why no work with controller"  [def: "true"]
 
-// ================ Shadows ================
-r_citadel_shadow_caching                    "false"         // We disable all shadows so this shouldn't be needed               [def: "true"]
-cl_globallight_shadow_mode                  "0"             // No idea. It is disabled based on the name.                       [def: "2"]
-lb_barnlight_shadowmap_scale                "0.5"           // Scale for computed barnlight shadowmap size (lower = cheaper).   [def: "1"]
-lb_csm_cascade_size_override                "1"             // Enables overriding CSM cascade sizing rules (forces engine to use override values). [def: "1536"]
-lb_csm_draw_alpha_tested                    "0"             // Prevents alpha-tested geometry from being included in CSM passes (cheaper, possible missing leaf/fence shadows). [def: "1"]
-lb_csm_draw_translucent                     "0"             // Prevents translucent objects from rendering into CSM (cheaper, fewer shadow details). [def: "1"]
-lb_csm_override_staticgeo_cascades          "0"             // Disables realistic static cascades/ shadows from being cast around dynamic shadows such as heroes, uses low quality baked shadows instead. [def: "1"]
-lb_csm_override_staticgeo_cascades_value    "-1"            // Base range of static cascade affects around player shadows. (-1 = minimal/disabled override behavior). [def: "-1"]
-lb_dynamic_shadow_resolution_base           "256"           // Base resolution for dynamic shadows (lower = cheaper).           [def: "1536"]
-lb_enable_shadow_casting                    "0"             // Disables baked shadows I believe                                 [def: "1"]
-lb_ssss_samples                             "1"             // Subsurface sample count                                          [def: "11"]
-lb_sun_csm_size_cull_threshold_texels       "30"            // Culls tiny CSM contributions below a texel threshold (performance).              [def: "10"]
-r_citadel_gpu_culling_shadows               "1"             // Enables GPU-driven culling for shadow casters (performance).     [def: "0"]
-r_citadel_shadow_quality                    "0"             // Deadlock/Citadel shadow quality level (0 = lowest).              [def: "2"]
-r_shadows                                   "0"             // Disables dynamic shadows.                                        [def: "1"]
-r_size_cull_threshold_shadow                "1"             // Threshold of shadow map size percentage below which objects get culled (higher = cull more to save shadow cost). [def: "0.2"]
-sc_disable_spotlight_shadows                "1"             // Disables spotlight shadows.                                      [def: "0"]
-sparseshadowtree_disable_for_viewmodel      "0"             // Disable SST generation and runtime for viewmodel (use original CSM rendering).   [def: "1"]
-sparseshadowtree_enable_rendering           "1"             // Enables Sparse Shadow Tree, rendering static geometry into shadow cascades.      [def: "0"]
+        // --- 1. Outlines ---
+        citadel_unit_status_allies_see_thru_walls              "true" // Do you want to see allied player outlines through walls          [def: "true"]
+        citadel_boss_glow_disabled                             "1"    // Disables boss and walker glow/highlight effect.                  [def: "0]
+        citadel_damage_offscreen_indicator_disabled            "true" // The little trooper portraits that show up behind walls.          [def: "true"]
+        citadel_player_glow_disabled                           "0"    // Disables player glow/highlight effect when pinged.               [def: "0"]
+        citadel_trooper_glow_disabled                          "1"    // 1 = Disable friendly/enemy minion glow.                          [def: "0"]
+        citadel_unit_status_allies_see_thru_walls_max_distance "40"   // How far to make allied players' unit status show through walls.  [def: "0"] (0 means no limit)
+        // citadel_unit_status_dpi                             "6"    // This increases the size of the health bar. Unfortunately I think this lowers performance. A shame. [def: "5"]
 
-// ================ Lighting ================
-mat_max_lighting_complexity                 "1"             // Doesn't seem to do anything but throwing it in for posterity.    [def: "8"]
-cl_retire_low_priority_lights               "1"             // Replaces/drops low-priority dynamic lights when higher-priority lights are present (helps cap dlight clutter/cost). [def: "0"]
-mat_async_shader_load                       "1"             // I have no reason to believe the name doesn't match the function  [def: "0"]
-mat_set_shader_quality                      "0"             // Force shader quality setting (valid values are 0 or 1).          [def: null]
-r_citadel_distancefield_farfield_enable     "0"             // Disables long-range distance field effects.                      [def: "1"]
-r_citadel_ssao_quality                      "0"             // SSAO quality level (0 = lowest/off-ish).                         [def: "3"]
-r_citadel_ssao_thin_occluder_compensation   "0"             // Disables special handling for thin occluders in SSAO (cheaper).  [def: "0.5"]
-r_citadel_sun_shadow_slope_scale_depth_bias "1.0"           // \\                                                               [def: "3.54"]
-r_directlighting                            "false"         // Set to true to have your characters not be black in the shop     [def:"true"]
-r_distancefield_enable                      "0"             // Disables/ Enables distance-field system (used by some lighting/shadowing/occlusion features). [def: "1"]
-r_light_flickering_enabled                  "1"             // Enables light flicker effects where used.                        [def: "1"]
-r_lightmap_bicubic_filtering                "1"             // Enables bicubic filtering on lightmaps.                          [def: "1"]
-r_lightmap_size                             "4"             // Maximum lightmap resolution..                                    [def: "65536"]
-r_lightmap_size_directional_irradiance      "4"             // Sets directional irradiance lightmap data size (lower = less detail) (-1 = uses value of r_lightmap_size ). [def: "-1"]
-r_multiscattering                           "1"             // Enables multi-scattering lighting approximation.                 [def: "1"]
-r_rendersun                                 "0"             // Disables sun lighting.                                           [def: "1"]
-r_ssao                                      "0"             // Disables screen-space ambient occlusion.                         [def: "1"]
-r_ssao_strength                             "0"             // AO strength multiplier (0 = no AO contribution).                 [def: "1.2"]
+        // --- 2. Field of View ---
+        // These commands both affect fov but do so in different ways. citadel_camera_hero_fov changes the field of view using typical degrees but doesn't modify the punch zoom in. This means that if you have a high fov value the zoom in can be disorienting.
+        // citadel_camera_hero_fov "106"  // The field of view angle of the camera when following a hero.     [def: "90"]
+        r_aspectratio              "2.80" // This command is commented out, represented by the // at the beginning of the line. Editing it will not do anything. To mess with it remove the //
+        // r_aspectratio changes the zoom of the camera which in turn doesn't make the punch zoom in as jarring, but the command is not as intuitive to set precisely
+        // 1.75=80fov | 2.15=90fov | 2.49=100fov (every .15 interval = 5 fov).
 
-// ================ Ragdolls ================
-cl_disable_ragdolls                         "0"             // Keep set to 0 - enabling this (disabling ragdolls) can cause issue with doorman's ultimate. [def: "0"]
-cl_ragdoll_limit                            "-1"            // Limit of how many ragdolls can be rendered at once.              [def: "-1"]
-ragdoll_parallel_pose_control               "1"             // Multithreaded ragdoll handling, better performance (if ragdolls aren't disabled). [def: "0"]
+        // --- 3. HUD ---
+        citadel_unit_status_delta_decay_rate               "2"       // how quickly the yellow to indicate damage fades from the health bar. [def: "3"]
+        // citadel_hud_objective_health_debug_show_midboss "true"    // This makes midboss' health bar visible whenever it's able to be rendered. I like it, you might not [def: "false"]
+        // citadel_unit_status_use_v2                      "0"       // Set to 1 to enable the new health bar that allows you to  see enemy stamina. [def: "0"]
+        // citadel_unit_status_use_v2_for_nonplayers       "0"       // Set to 1 to enable the new health bar but for troopers, objs, and camps.     [def: "0"]
+        citadel_crosshair_hit_marker_duration              "0.00001" // Removes the hitmarker when shooting people.                      [def: "0.1"]
+        citadel_damage_report_enable                       "1"       // Enables/Disables incoming/outgoing damage tab (tuning this off is very questionable but okay). [def: "1"]
+        citadel_damage_text_batching_window_ability        "1000"    // How long to wait until batching damage text.
+        citadel_hideout_ball_show_juggle_count             "1"       // Shows a fun juggle count minigame for hideout ball.              [def: "0"]
+        citadel_hideout_ball_show_juggle_fx                "1"       // Shows juggle visual FX for hideout ball minigame.                [def: "0"]
+        citadel_hud_objective_health_enabled               "2"       // 0=Off, 1=Shrines, 2=T1/T2, 3=Barracks.                           [def: "2"]
+        citadel_unit_status_use_new                        "1"       // This uses new Health Bar, to use old Health Bar change "true" to "false".    [def: "0"]
+        citadel_show_chat_wheel_angle_threshold            "0"       // (degrees) Increase this to change how much you have to move your camera angle to make the Chat Wheel instantly visible while holding Ping. [def: "16"]
 
-// ================ Models ================
-animgraph_enable_parallel_op_evaluation     "1"             // Allows animgraph operator evaluation to run in parallel (performance).   [def: "0"]
-animgraph_enable_parallel_preupdate         "1"             // Allows animgraph pre-update work to run in parallel (performance).       [def: "0"]
-cl_fasttempentcollision                     "1000"          // Limits/controls fast collision processing for temporary entities (impacts/tracers/etc.); higher usually = more work. [def: "5"]
-cloth_sim_on_tick                           "0"             // Update the cloth simulation every tick                           [def: "1"]
-enable_boneflex                             "0"             // Disables bone flexes (procedural facial/mesh flex drivers).      [def: "1"]
-ik_fabrik_align_chain                       "0"             // Disables FABRIK chain alignment in IK (cheaper).                 [def: "1"]
-ik_final_fixup_enable                       "0"             // Disables final IK fixup pass (cheaper animations, potentially less accurate). [def: "1"]
-phys_threaded_cloth_bone_update             "1"             // I am inclined to believe this makes the cloth update threaded    [def: "0"]
-phys_threaded_kinematic_bone_update         "1"             // I am inclined to believe this makes the cloth kinematics threaded    [def: "0"]
-phys_threaded_transform_update              "1"             // Same as above                                                    [def: "0"]
-props_break_max_pieces_perframe             "0"             // Makes boxes and troopers break into a single piece               [def: "16"]
-// In future updates hopefully this being set to 0 will cause them to not leave any pieces behind
-r_hair_ao                                   "0"             // Disables hair ambient occlusion/shading pass.                    [def: "1"]
+        // --- 4. Lighting & Shadows ---
+        lb_enable_baked_shadows     "0" // *Disables baked shadows (game looks bright if this is on while stationary lights = 1). [def: "1"]
+        lb_enable_dynamic_lights    "1" // *Disables dynamic lights eg. walker, shop, tp, character abilities etc. (hero silhouettes go dark in menus as a side effect) [def: "1"]
+        lb_enable_stationary_lights "0" // *Disables stationary lights (map looks flatter but more performant).         [def: "1"]
 
-// ================ Visual Clarity ================
-cl_show_splashes                            "0"             // Disables splash effects (water/impact splashes).                 [def: "1"]
-mat_colorcorrection                         "1"             // Disables/ Enables color correction (game looks less vibrant when off).   [def: "1"]
-r_character_decal_resolution                "1"             // Resolution of character decal texture.                           [def: "1024"]
-r_decals                                    "1"             // Maximum number of decals allowed. (lower = fewer bullet holes/blood/impact marks). [def: "2048"]
-r_decals_default_fade_duration              "1"             // How quickly decals (bullet holes) fade                           [def: "3"]
-r_depth_of_field                            "0"             // Disables depth of field.                                         [def: "1"]
-r_drawdecals                                "1"             // *Render decals.                                                  [def: "1"]
-r_effects_bloom                             "0"             // Disables effects bloom.                                          [def: "1"]
-r_post_bloom                                "0"             // Disables post-process bloom.                                     [def: "1"]
-sc_clutter_enable                           "false"         // Disables clutter props, improves visibility & FPS.               [def: "true"]
-violence_ablood                             "0"             // Disables alien/other blood effects.                              [def: "1"]
-violence_agibs                              "0"             // Disables alien/other gibs.                                       [def: "1"]
-violence_hblood                             "0"             // Disables human blood effects.                                    [def: "1"]
-violence_hgibs                              "0"             // Disables human gibs.                                             [def: "1"]
-volume_fog_intermediate_textures_hdr        "false"         // See below                                                        [def: "true"]
-// Based on the name I would assume that this changes the color depth of the fog. Since the majority of users don't have hdr panels or want bloom, setting this to false is beneficial
+        // --- 5. Skybox Rendering ---
+        r_draw3dskybox "0" //  Enables drawing the 3D skybox layer (distant geometry).         [def: "1"]
 
-// ================ Network ================
-// Don't mess with network commands yet
-cl_async_usercmd_send                       "true"          // Makes the client send updates asyncronously I belive. Seems to smooth over network jank, although you will need to remove it from lower down in the gameinfo.gi [def: "false"]
-//cl_updaterate                             "128"           // Client snapshot update rate requested from the server (higher = more frequent updates).      [def: "128"]
-//cl_interp                                 "0.01"          // Client-side interpolation time (smoothing delay) for rendering other players/entities.       [def: 0]
-//cl_interp_ratio                           "1"             // Multiplier that affects interpolation time (often cl_interp_ratio / cl_updaterate).              [def: "0"]
-//cl_smoothtime                             "0.01"          // Smooth client's view after prediction error over this many seconds (Lower = snappier but more abrupt, higher = smoother but floaty). [def: "0.2"]
-//cl_resend                                 "15"            // Delay in seconds between reconnect attempts (higher = less frequent, helps avoid kicks/timeouts on unstable connections). [def: "0.5"]
+        // --- 6. FPS Caps & Minimized Throttling ---
+        engine_low_latency_sleep_after_client_tick "true" // Sleeps strategically after client tick to reduce latency/stutter (low-latency pacing). [def: "false"]
+        engine_no_focus_sleep                      "20"   // Milliseconds the engine sleeps per frame when unfocused (0 = no sleep, not recommended for low-end PC). [def: "20"]
+        fps_max                                    "0"    // Max FPS while in game, limit fps to your monitor refresh rate. [def: "400"]
+        panorama_max_fps                           "30"   // Menu FPS.                                                        [def: "120"]
+        panorama_max_overlay_fps                   "30"   // Fps In the settings/esc menu.                                    [def: "60"]
 
-// ================ System Related ================
-// Chances are these don't matter so you can ignore them
-battery_saver                               "0"             // Disables battery saver mode (no automatic throttling).                   [def: "0"]
-cpu_level                                   "1"             // CPU level.                                                               [def: "2"]
-enable_priority_boost                       "true"          //
-gpu_mem_level                               "1"             // GPU Memory level.                                                        [def: "2"]
-//think_limit                               "0.001"         // Limits how much “think” time/entities can process per tick (CPU cap).    [def: "10"]
-//^ *TODO I am going to need to test this to make sure lowering it doesn't cause problems.
+        // --- 7. Object Culling ---
+        r_size_cull_threshold "0.9" // *Culls small objects sooner based on screen size threshold (higher = more culling). [def: "0.8"]
 
-// ================ Input ================
-cl_input_enable_raw_keyboard                "1"             // Enables raw keyboard input handling (more direct input path).[def: "0"]
+        // --- 8. Camera Tweaks ---
 
-// ================ Particles ================
-particle_cluster_use_collision_hulls        "false"         // Should make particles able to pass through each other. Saves some perf   [def: "true"]
-r_update_particles_on_render_only_frames    "true"          // This does what it says on the tin, should save more performance the lower fps gets   [def: "false"]
-r_particle_fixedrandomseeds                 "true"          // I need to properly test this, but I'm pretty sure that setting this to true marginally increases performance [def: "false"]
-r_citadel_screenspace_particles_full_res    "false"         // Render screen space particles at full resolution. This could introduce readability issues but should be fine.
-r_particle_mixed_resolution_viewstart       "16"            // I don't know if this does anything but I didn't notice anything terrible out the gate and lowering particle resolution can't hurt [def: "500"]
-cl_particle_batch_mode                      "1"             // Has a range of 1 or 2, 2 will make celeste's auto rebound look weird and 0 will make them not batch [def: "1"]
-cl_particle_fallback_base                   "10"            // Base for falling back to cheaper effects under load.             [def: "0"] 
-cl_particle_fallback_multiplier             "20"            // Multiplier for falling back to cheaper effects under load.       [def: "0"]
-cl_particle_sim_fallback_base_multiplier    "40"            // How aggressive the switch to fallbacks will be depending on how far over the cl_particle_sim_fallback_threshold_ms the sim time is.  Higher numbers are more aggressive. [def: "5"] 
-cl_particle_sim_fallback_threshold_ms       "1"             // Amount of simulation time that can elapse before new systems start falling back to cheaper versions [def: "6"] 
-particle_cluster_nodraw                     "1"             // Skips drawing particle “clusters”/grouped particle batches (performance, fewer small effects). [def: "0"]
-r_RainParticleDensity                       "0"             // Density of Particle Rain 0-1.                                    [def: "1"]
-r_draw_particle_children_with_parents       "0"             // I believe this handles the drawing of little visual flourish particles. [def: "-1"]
-r_late_particle_job_sync                    "true"          // No idea                                                          [def: "false"]
-r_limit_particle_job_duration               "true"          // Seems to help with particle clutter, although I am not sure.             [def: "false"]
-r_particle_allowprerender                   "false"         // I imagine it renders particles prematurely, which we do not care for.    [def: "true"]
-r_particle_batch_collections                "true"          // Batches collections of particles, typically batch rendering is faster so this is set to true. [def: "false"]
-r_particle_max_detail_level                 "1"             // The maximum detail level of particle to create.                  [def: "3"]
-r_particle_max_texture_layers               "4"             // Anything below 4 will make infernus afterburn, paige fire, and drifter's passive look very weird and blocky [def: "-1"]
-r_particle_model_per_thread_count           "64"            // I believe it is how many particle models a thread is allowed to handle.  [def: "32"]
-r_particle_skip_postsim                     "true"          // Not entirely sure what it does, going off of the name I'd imagine it skips the post simulation, this is a testvar [def: "false"]
-//r_particle_timescale                        "1.1"           // Speeds up particle simulation, thus making them end sooner, however this causes visual desyncs, most notably with big effects that last a while such as infernus ult. Please tweak this to what you are comfortable with. [def: "1"]
-cl_aggregate_particles                      "true"          // Doesn't seem to cause any issues but a benchmark proper should be conducted [def: "false"]
-r_physics_particle_op_spawn_scale           "0"             // Prevents physics-based particle spawns.                          [def: "1"]
-r_world_wind_strength                       "0"             // Disables wind effects, cosmetic only.                            [def: "40"]
+        // citadel_camera_listening_offset    "-1"   // To be completely honest I have no idea but I want to test this.  [def: "0"]
+        citadel_camera_soft_collision_angle   "360"  //                                                                  [def: "75"]
+        r_citadel_clip_sphere_min_opacity     "0"    // Removes the blur from the pinhole camera                         [def: "40"]
+        // r_citadel_clip_sphere_skin         "0.01" //                                                                  [def: "0.01"]
+        // r_citadel_clip_sphere_cone_angle   "40"   //                                                                  [def: "40"]
+        // r_citadel_clip_sphere_distance_max "75"   //                                                                  [def: "75"]
+        // These are various commands for messing with the pinhole camera. I don't fully understand them and they can be ignored for now.
 
-// ================ Lod & Culling ================
-sc_allow_dithered_lod                       "false"         // Pretty sure this just turns dithering off for when switching between lods. Isn't a big deal [def: "true"]
-//sc_instanced_mesh_size_cull_bias          "10"            // Bias for size culling of instanced meshes                        [def: "1.5"]
-citadel_use_pvs_for_players                 "true"          // Default culls players when out of view                           [def: "false"]
-mat_viewportscale                           "0.01"          // Scale down the main viewport I belive this gets overwritten by video.txt [def: "1"]
-phys_cull_internal_mesh_contacts            "true"          // Don't simulate the bones inside of a mesh.                       [def: "false"]
-sc_aggregate_bvh_threshold                  "128"           // Not fully sure what these do. Don't change them.                 [def: "128"]
-sc_fade_distance_scale_override             "100"           // Distance objects fade in and out                                 [def: "-1"]
-sc_instanced_mesh_lod_bias                  "0.15"          // Bias for LOD selection of instanced mesh                         [def: "1.25"]
-sc_instanced_mesh_lod_bias_shadow           "0.10"          // Bias for LOD selection of instanced meshes in shadowmaps         [def: "1.75"]
-sc_instanced_mesh_motion_vectors            "0"             // Set 1 if you use motion blur                                     [def: "1"]
-sc_instanced_mesh_size_cull_bias_shadow     "10"            // Bias for size culling instanced meshes in shadowmaps             [def: "2"]
-sc_layer_batch_threshold                    "128"           // Not fully sure what these do. Don't change them.                 [default: "128"]
-sc_layer_batch_threshold_fullsort           "80"            // Not sure what these do. Jasper said to leave them at default     [def: "80"]
-sc_screen_size_lod_scale_override           "0.5"           // Controls LOD scale. Lower values will have less polys            [def: "-1"]
-skeleton_instance_lod_optimization          "false"         // Compute LOD mask internally like since 2016, i.e. force all LOD groups' bones to compute [def: "false"]
+        // citadel_camera_hard_trace_radius       "32"  // The radius of the cylinder to trace for hard camera occlusion. Based on reading the cvars docs I assume this is like the bounding box of the camera [def: "16"]
+        // citadel_fibonnaci_sphere_trace_los_max "160" // How big to cap the size of the sphere when checking for really large explosion/effects [def: "160"]
 
-// ================ Rendering Stuff ================ 
-r_citadel_gpu_culling                       "true"          // The game barely uses the gpu so this is a win                    [def: "true"]
-r_citadel_gpu_culling_two_pass              "false"         // Assuming that this is culling passes this should be faster       [def: "true"]
-r_frame_sync_enable                         "false"         // No documentation, not sure if this does anything                 [def: "true"]
-r_force_zprepass                            "0"             // 0: Force z prepass off. 1: Force on. -1: Don't force             [def: "-1"]
-// With my understanding of how zprepasses work this should reduce cpu usage if set to zero, but that's under the assumption that valve's implementation isn't properly optimized. Please play with this. Your mileage may vary.
-r_vma_defrag_algorithm                      "0"             // Should speed up vulkan defragging, which could increase performance if you're  getting bad performance the longer a match goes on [def: "1"]
-rtx_dynamic_blas                            "false"         // Don't think that raytracing is used, but I'm making sure         [def: "true"]
-rtx_dynamic_blas_caching                    "false"         //                                                                  [def: "true"]
-rtx_force_default_hitgroup                  "true"          //                                                                  [def: "false"]
-rtx_texture_resolution                      "64"            //                                                                  [def: "true"]
-citadel_video_preset                        "2"             // Rendering performance level. min 0, max 3                        [def: "3"]
-//sc_aggregate_indirect_draw_compaction_threshold "1"         // Need to test                                                   [def: "8"]
-sc_instanced_mesh_opaque_fade               "false"         // Fade meshes? NAH                                                 [def: "true"]
-sc_aggregate_render_mesh_shader             "false"         // Using mesh shaders if available instead of drawcalls. Should be cheaper [def: "true"]
-sc_aggregate_rtproxy_instanced_geo          "false"         // 
-sc_aggregate_rtproxy_unique_geo             "false"         // 
-sc_allow_dithered_lod                       "false"         // 
+        // Uncommenting these cvars will make it so that you can look above/behind yourself. It's kinda awesome but reverses your movement input and could make some people motion sick.
+        // citadel_camera_pitch_max "160"  // The maximum pitch angle allowed on the camera.                 [def: "89"]
+        // citadel_camera_pitch_min "-160" // The minimum pitch angle allowed on the camera.                 [def: "-89"]
+
+        // --- 9. Texture Quality ---
+        r_texture_budget_threshold     "0.7" // Reduce texture memory pool size when this percentage of the budget is full. [def: "0.8"]
+        r_texture_budget_update_period "0.5" // Time (in seconds) between updating texture memory budget.        [def: "0.1"]
+        r_texture_stream_mip_bias      "3"   // Worth adjusting, practically how good your textures will look.   [def: "1"]
+        r_texturefilteringquality      "3"   // Texture filtering, has very low fps impact. 0: Bilinear, 1: Trilinear, 2: Aniso 2x, 3: Aniso 4x, 4: Aniso 8x, 5: Aniso 16x
+
+        // --- 10. Render Distance ---
+        r_farz       "8192" // This controls the far clipping plane, ie building/player popin   [def: "-1"]
+        r_mapextents "8192" // Far clipping plane, this will make buildings pop in and out      [def: "16384"] damn that's an oddly specific number
+
+        // ================ IMPORTANT ================
+        thread_pool_option "-1" // If I understand correctly, this should be how threads are handled relative to the game, but there isn't a clear indication of what changing it even does. For now I have it at -1 which is the default, but your mileage may vary. [def: "-1"]
+        // 1 gives "GlobalThreadPoolMode" "efficiency"
+        // 2 removes it from boot.vcfg
+        // 3 gives "GlobalThreadPoolMode" "undifferentiated"
+        // 4 gives "GlobalThreadPoolMode" "auto_threads"
+        // 5 removes it from boot.vcfg
+        // 6 gives "GlobalThreadPoolMode" ""max_threads"
+        // 7-10 removes it from boot.vcfg
+
+        // -1 Default
+        // -2 removes it from boot.vcfg
 
 
-// ================ Misc ================
-cl_frametime_summary_report_detailed        "false"         // Might cause issues for devs but we shouldn't need this           [def: "true"]
-citadel_perf_interval_report_s              "100000"        // The interval that we record performance stats to the log at measured in seconds [def: "60"]
-disable_source_soundscape_trace             "true"          // Bypasses lookup of soundscapes for indvidual audio sources when enabled. [def: "false"]
-cc_captiontrace                             "0"             // Show missing closecaptions (0 = no, 1 = devconsole, 2 = show in hud) [def: "1"]
-r_particle_model_new                        "false"         // Jasper stated that these variables aren't used by deadlock so I'm disabling them to be safe :steam_happy:    [def: "false"]
-r_particle_model_new8                       "false"         // Jasper stated that these variables aren't used by deadlock so I'm disabling them to be safe :steam_happy:    [def: "true"]
-r_pixelvisibility_partial                   "false"         // As far as I am aware this disables the pixel visibility system which should reduce visual fidelity but saves you from drawing a ray (I THINK) [def: "true"]
-//r_pipeline_stats_use_flush_api              "false"         // Experimental: Set to 1 to use the ID3D11DeviceContext11::Flush() to flush the GPU pipeline instead of queries. [def: "true"]
-r_skip_precache_validation_check            "true"          // I believe this checks to see if things are properly cached in a debug context, which we shouldn't need   [def: "false"]
-cl_batch_entity_list_ops_during_latch       "true"          // Batch entity list adds / removes while latching interpolated variables to avoid mutex contention.        [def: "false"]
-cl_interp_parallel                          "true"          // Run interpolation in parallel for entities with no children.     [def: "false"]
-cl_modifier_parallel_gather_status_effect_updates   "true"  // Not sure                                                         [def: "false"]
-cl_phys_assume_fixed_tick_interval          "false"         // Assume the client uses a fixed tickrate like the server (which may not always be true)                   [def: "true"]
-engine_max_ticks_to_simulate                "2"             // Max number of ticks to simulate per frame, after which simulation will start to slow down compared to real time. [def: "-1"]
-nav_obstruction_async_update                "true"          // Not fully sure but async good wowie                              [def: "false"]
-parallel_perform_invalidate_physics         "true"          // Not sure                                                         [def: "false"]
-r_async_compute_fog                         "true"          // Just whether to asyncroniously render fog                        [def: "false"]
-r_citadel_depth_prepass_dynamic_objects     "false"         // Should be not prepassing entities that move                      [def: "true"]
-r_low_latency                               "1"             // This acts as the convar which enables low latency, hardware dependent    [def: "1"]
-r_renderdoc_auto_shader_pdbs                "false"         // Automatically generate shader debug info on capture.             [def: "true"]
-save_parallel                               "true"          // Absolutely no idea but typically paralell processing is good.    [def: "false"]
-sc_force_materials_batchable                "true"          // I would imagine this functions as the variable is named.         [def: "false"]
-r_max_portal_render_targets                 "2"             // Maxium number of Doorman doors to allow rendering.               [def: "0"]
-// ^ This will cause visual bugs when set to 1, either set it to 2 or 0 to disable them.
+        // ================= UI ================
+        citadel_damage_text_show_effectiveness "0"     // Shows extra “effectiveness” info in damage text (e.g., resist/weakness style feedback). [def: "0"]
+        closecaption                           "false" // I assume this does what it says on the tin                       [def: "false"]
+        panorama_allow_transitions             "false" // Turns off UI anim (shop,etc)                                     [def: "1"]
+        panorama_disable_blur                  "1"     // Disables UI blur effects in the UI.                              [def: "0"]
+        panorama_disable_box_shadow            "1"     // Disables UI box shadows in the UI (less GPU/UI cost).            [def: "0"]
+        panorama_temp_comp_layer_min_dimension "128"   // Based on the name I'm implied to believe this is the minimum size for panorama compositing, ie blur, rounded corners, etc. [def: "512"]
+        r_citadel_enable_pano_world_blur       "true"
+        r_dashboard_render_quality             "0" // Sets dashboard/UI render quality (lower = cheaper UI rendering). [def: "1"]
 
-// ================ Grass ================
-r_grass_end_fade                            "0"             // When to cull grass when far                                      [def: "300"]
-r_grass_quality                             "0"             // Quality of the grass                                             [def: "2"]
-r_grass_start_fade                          "0"             // When to cull grass when it's close I think                       [def: "0"]
+        // ================ Shadows ================
+        r_citadel_shadow_caching                 "false" // We disable all shadows so this shouldn't be needed               [def: "true"]
+        cl_globallight_shadow_mode               "0"     // No idea. It is disabled based on the name.                       [def: "2"]
+        lb_barnlight_shadowmap_scale             "0.5"   // Scale for computed barnlight shadowmap size (lower = cheaper).   [def: "1"]
+        lb_csm_cascade_size_override             "1"     // Enables overriding CSM cascade sizing rules (forces engine to use override values). [def: "1536"]
+        lb_csm_draw_alpha_tested                 "0"     // Prevents alpha-tested geometry from being included in CSM passes (cheaper, possible missing leaf/fence shadows). [def: "1"]
+        lb_csm_draw_translucent                  "0"     // Prevents translucent objects from rendering into CSM (cheaper, fewer shadow details). [def: "1"]
+        lb_csm_override_staticgeo_cascades       "0"     // Disables realistic static cascades/ shadows from being cast around dynamic shadows such as heroes, uses low quality baked shadows instead. [def: "1"]
+        lb_csm_override_staticgeo_cascades_value "-1"    // Base range of static cascade affects around player shadows. (-1 = minimal/disabled override behavior). [def: "-1"]
+        lb_dynamic_shadow_resolution_base        "256"   // Base resolution for dynamic shadows (lower = cheaper).           [def: "1536"]
+        lb_enable_shadow_casting                 "0"     // Disables baked shadows I believe                                 [def: "1"]
+        lb_ssss_samples                          "1"     // Subsurface sample count                                          [def: "11"]
+        lb_sun_csm_size_cull_threshold_texels    "30"    // Culls tiny CSM contributions below a texel threshold (performance).              [def: "10"]
+        r_citadel_gpu_culling_shadows            "1"     // Enables GPU-driven culling for shadow casters (performance).     [def: "0"]
+        r_citadel_shadow_quality                 "0"     // Deadlock/Citadel shadow quality level (0 = lowest).              [def: "2"]
+        r_shadows                                "0"     // Disables dynamic shadows.                                        [def: "1"]
+        r_size_cull_threshold_shadow             "1"     // Threshold of shadow map size percentage below which objects get culled (higher = cull more to save shadow cost). [def: "0.2"]
+        sc_disable_spotlight_shadows             "1"     // Disables spotlight shadows.                                      [def: "0"]
+        sparseshadowtree_disable_for_viewmodel   "0"     // Disable SST generation and runtime for viewmodel (use original CSM rendering).   [def: "1"]
+        sparseshadowtree_enable_rendering        "1"     // Enables Sparse Shadow Tree, rendering static geometry into shadow cascades.      [def: "0"]
 
-// ================ Creep AI ================
-ai_strong_optimizations_no_checkstand       "1"             // Not fully sure what exactly this does, but I would imagine given the name of the convar it optimizes ai. [def: "0"]
-citadel_npc_force_animate_every_tick        "false"         // Don't change this, it does what it says on the tin.              [def: "true"]
-cl_simulate_dormant_entities                "false"         // Based on the name I would imagine it does what it says.          [def: "true"]
+        // ================ Lighting ================
+        mat_max_lighting_complexity                 "1"     // Doesn't seem to do anything but throwing it in for posterity.    [def: "8"]
+        cl_retire_low_priority_lights               "1"     // Replaces/drops low-priority dynamic lights when higher-priority lights are present (helps cap dlight clutter/cost). [def: "0"]
+        mat_async_shader_load                       "1"     // I have no reason to believe the name doesn't match the function  [def: "0"]
+        mat_set_shader_quality                      "0"     // Force shader quality setting (valid values are 0 or 1).          [def: null]
+        r_citadel_distancefield_farfield_enable     "0"     // Disables long-range distance field effects.                      [def: "1"]
+        r_citadel_ssao_quality                      "0"     // SSAO quality level (0 = lowest/off-ish).                         [def: "3"]
+        r_citadel_ssao_thin_occluder_compensation   "0"     // Disables special handling for thin occluders in SSAO (cheaper).  [def: "0.5"]
+        r_citadel_sun_shadow_slope_scale_depth_bias "1.0"   // \\                                                               [def: "3.54"]
+        r_directlighting                            "false" // Set to true to have your characters not be black in the shop     [def:"true"]
+        r_distancefield_enable                      "0"     // Disables/ Enables distance-field system (used by some lighting/shadowing/occlusion features). [def: "1"]
+        r_light_flickering_enabled                  "1"     // Enables light flicker effects where used.                        [def: "1"]
+        r_lightmap_bicubic_filtering                "1"     // Enables bicubic filtering on lightmaps.                          [def: "1"]
+        r_lightmap_size                             "4"     // Maximum lightmap resolution..                                    [def: "65536"]
+        r_lightmap_size_directional_irradiance      "4"     // Sets directional irradiance lightmap data size (lower = less detail) (-1 = uses value of r_lightmap_size ). [def: "-1"]
+        r_multiscattering                           "1"     // Enables multi-scattering lighting approximation.                 [def: "1"]
+        r_rendersun                                 "0"     // Disables sun lighting.                                           [def: "1"]
+        r_ssao                                      "0"     // Disables screen-space ambient occlusion.                         [def: "1"]
+        r_ssao_strength                             "0"     // AO strength multiplier (0 = no AO contribution).                 [def: "1.2"]
 
-// ================ Audio ================
-audio_enable_vmix_mastering                 "false"         // Whether the engine uses vmix to master the audio, might be a dev command [def: "true"]
-snd_mixahead                                "0.05"          // Adds some latency that shouldn't be percivable to save cpu       [def: "0.001"]
-snd_occlusion_bounces                       "0"             // Limits audio occlusion to save cpu                               [def: "1"]
-snd_occlusion_rays                          "0"             // Occlusion bounces, this effectively disables them.               [def: "4"]
-snd_soundmixer_version                      "1"             // [def: "2"]
-snd_steamaudio_reverb_order_rendering       "0"             // The amount of directional detail in the rendered audio by Steam Audio. [def: "0"]
-snd_ui_positional                           "false"         // Disables positional audio to save cpu                            [def: "true"]
-snd_steamaudio_num_threads                  "4"             // Audio thread count                                               [def: "4"]
-// README This ^ probably depends on how good your cpu is, the better it is the more threads you can allow
+        // ================ Ragdolls ================
+        cl_disable_ragdolls           "0"  // Keep set to 0 - enabling this (disabling ragdolls) can cause issue with doorman's ultimate. [def: "0"]
+        cl_ragdoll_limit              "-1" // Limit of how many ragdolls can be rendered at once.              [def: "-1"]
+        ragdoll_parallel_pose_control "1"  // Multithreaded ragdoll handling, better performance (if ragdolls aren't disabled). [def: "0"]
 
-// ================ Csm Shadows. ================
-// According to jasper these shouldn't do anything, but I'm keeping them because they seemed to provide a performance increase with them disabled
-// I need to do benchmarks of the config with and without these commands, however I am LAZY
-csm_cascade0_override_dist                  "0"             // All of these commands should reduce shadow quality.
-csm_cascade1_override_dist                  "0"             // All of these commands should reduce shadow quality.
-csm_cascade2_override_dist                  "0"             // All of these commands should reduce shadow quality.
-csm_cascade3_override_dist                  "0"             // All of these commands should reduce shadow quality.
-csm_max_dist_between_caster_and_receiver    "0"             // All of these commands should reduce shadow quality.
-csm_max_num_cascades_override               "0"             // All of these commands should reduce shadow quality.
-csm_max_shadow_dist_override                "1"             // All of these commands should reduce shadow quality.
-csm_max_visible_dist                        "0"             // All of these commands should reduce shadow quality.
-csm_res_override_0                          "1"             // All of these commands should reduce shadow quality.
-csm_res_override_1                          "1"             // All of these commands should reduce shadow quality.
-csm_res_override_2                          "1"             // All of these commands should reduce shadow quality.
-csm_res_override_3                          "1"             // All of these commands should reduce shadow quality.
-csm_viewmodel_shadows                       "false"         // All of these commands should reduce shadow quality.
+        // ================ Models ================
+        animgraph_enable_parallel_op_evaluation "1"    // Allows animgraph operator evaluation to run in parallel (performance).   [def: "0"]
+        animgraph_enable_parallel_preupdate     "1"    // Allows animgraph pre-update work to run in parallel (performance).       [def: "0"]
+        cl_fasttempentcollision                 "1000" // Limits/controls fast collision processing for temporary entities (impacts/tracers/etc.); higher usually = more work. [def: "5"]
+        cloth_sim_on_tick                       "0"    // Update the cloth simulation every tick                           [def: "1"]
+        enable_boneflex                         "0"    // Disables bone flexes (procedural facial/mesh flex drivers).      [def: "1"]
+        ik_fabrik_align_chain                   "0"    // Disables FABRIK chain alignment in IK (cheaper).                 [def: "1"]
+        ik_final_fixup_enable                   "0"    // Disables final IK fixup pass (cheaper animations, potentially less accurate). [def: "1"]
+        phys_threaded_cloth_bone_update         "1"    // I am inclined to believe this makes the cloth update threaded    [def: "0"]
+        phys_threaded_kinematic_bone_update     "1"    // I am inclined to believe this makes the cloth kinematics threaded    [def: "0"]
+        phys_threaded_transform_update          "1"    // Same as above                                                    [def: "0"]
+        props_break_max_pieces_perframe         "0"    // Makes boxes and troopers break into a single piece               [def: "16"]
+        // In future updates hopefully this being set to 0 will cause them to not leave any pieces behind
+        r_hair_ao "0" // Disables hair ambient occlusion/shading pass.                    [def: "1"]
+
+        // ================ Visual Clarity ================
+        cl_show_splashes                     "0"     // Disables splash effects (water/impact splashes).                 [def: "1"]
+        mat_colorcorrection                  "1"     // Disables/ Enables color correction (game looks less vibrant when off).   [def: "1"]
+        r_character_decal_resolution         "1"     // Resolution of character decal texture.                           [def: "1024"]
+        r_decals                             "1"     // Maximum number of decals allowed. (lower = fewer bullet holes/blood/impact marks). [def: "2048"]
+        r_decals_default_fade_duration       "1"     // How quickly decals (bullet holes) fade                           [def: "3"]
+        r_depth_of_field                     "0"     // Disables depth of field.                                         [def: "1"]
+        r_drawdecals                         "1"     // *Render decals.                                                  [def: "1"]
+        r_effects_bloom                      "0"     // Disables effects bloom.                                          [def: "1"]
+        r_post_bloom                         "0"     // Disables post-process bloom.                                     [def: "1"]
+        sc_clutter_enable                    "false" // Disables clutter props, improves visibility & FPS.               [def: "true"]
+        violence_ablood                      "0"     // Disables alien/other blood effects.                              [def: "1"]
+        violence_agibs                       "0"     // Disables alien/other gibs.                                       [def: "1"]
+        violence_hblood                      "0"     // Disables human blood effects.                                    [def: "1"]
+        violence_hgibs                       "0"     // Disables human gibs.                                             [def: "1"]
+        volume_fog_intermediate_textures_hdr "false" // See below                                                        [def: "true"]
+        // Based on the name I would assume that this changes the color depth of the fog. Since the majority of users don't have hdr panels or want bloom, setting this to false is beneficial
+
+        // ================ Network ================
+        // Don't mess with network commands yet
+        cl_async_usercmd_send "true" // Makes the client send updates asyncronously I belive. Seems to smooth over network jank, although you will need to remove it from lower down in the gameinfo.gi [def: "false"]
+        // cl_updaterate      "128"  // Client snapshot update rate requested from the server (higher = more frequent updates).      [def: "128"]
+        // cl_interp          "0.01" // Client-side interpolation time (smoothing delay) for rendering other players/entities.       [def: 0]
+        // cl_interp_ratio    "1"    // Multiplier that affects interpolation time (often cl_interp_ratio / cl_updaterate).              [def: "0"]
+        // cl_smoothtime      "0.01" // Smooth client's view after prediction error over this many seconds (Lower = snappier but more abrupt, higher = smoother but floaty). [def: "0.2"]
+        // cl_resend          "15"   // Delay in seconds between reconnect attempts (higher = less frequent, helps avoid kicks/timeouts on unstable connections). [def: "0.5"]
+
+        // ================ System Related ================
+        // Chances are these don't matter so you can ignore them
+        battery_saver         "0"     // Disables battery saver mode (no automatic throttling).                   [def: "0"]
+        cpu_level             "1"     // CPU level.                                                               [def: "2"]
+        enable_priority_boost "true"  //
+        gpu_mem_level         "1"     // GPU Memory level.                                                        [def: "2"]
+        // think_limit        "0.001" // Limits how much “think” time/entities can process per tick (CPU cap).    [def: "10"]
+        //^ *TODO I am going to need to test this to make sure lowering it doesn't cause problems.
+
+        // ================ Input ================
+        cl_input_enable_raw_keyboard "1" // Enables raw keyboard input handling (more direct input path).[def: "0"]
+
+        // ================ Particles ================
+        particle_cluster_use_collision_hulls     "false" // Should make particles able to pass through each other. Saves some perf   [def: "true"]
+        r_update_particles_on_render_only_frames "true"  // This does what it says on the tin, should save more performance the lower fps gets   [def: "false"]
+        r_particle_fixedrandomseeds              "true"  // I need to properly test this, but I'm pretty sure that setting this to true marginally increases performance [def: "false"]
+        r_citadel_screenspace_particles_full_res "false" // Render screen space particles at full resolution. This could introduce readability issues but should be fine.
+        r_particle_mixed_resolution_viewstart    "16"    // I don't know if this does anything but I didn't notice anything terrible out the gate and lowering particle resolution can't hurt [def: "500"]
+        cl_particle_batch_mode                   "1"     // Has a range of 1 or 2, 2 will make celeste's auto rebound look weird and 0 will make them not batch [def: "1"]
+        cl_particle_fallback_base                "10"    // Base for falling back to cheaper effects under load.             [def: "0"]
+        cl_particle_fallback_multiplier          "20"    // Multiplier for falling back to cheaper effects under load.       [def: "0"]
+        cl_particle_sim_fallback_base_multiplier "40"    // How aggressive the switch to fallbacks will be depending on how far over the cl_particle_sim_fallback_threshold_ms the sim time is.  Higher numbers are more aggressive. [def: "5"]
+        cl_particle_sim_fallback_threshold_ms    "1"     // Amount of simulation time that can elapse before new systems start falling back to cheaper versions [def: "6"]
+        particle_cluster_nodraw                  "1"     // Skips drawing particle “clusters”/grouped particle batches (performance, fewer small effects). [def: "0"]
+        r_RainParticleDensity                    "0"     // Density of Particle Rain 0-1.                                    [def: "1"]
+        r_draw_particle_children_with_parents    "0"     // I believe this handles the drawing of little visual flourish particles. [def: "-1"]
+        r_late_particle_job_sync                 "true"  // No idea                                                          [def: "false"]
+        r_limit_particle_job_duration            "true"  // Seems to help with particle clutter, although I am not sure.             [def: "false"]
+        r_particle_allowprerender                "false" // I imagine it renders particles prematurely, which we do not care for.    [def: "true"]
+        r_particle_batch_collections             "true"  // Batches collections of particles, typically batch rendering is faster so this is set to true. [def: "false"]
+        r_particle_max_detail_level              "1"     // The maximum detail level of particle to create.                  [def: "3"]
+        r_particle_max_texture_layers            "4"     // Anything below 4 will make infernus afterburn, paige fire, and drifter's passive look very weird and blocky [def: "-1"]
+        r_particle_model_per_thread_count        "64"    // I believe it is how many particle models a thread is allowed to handle.  [def: "32"]
+        r_particle_skip_postsim                  "true"  // Not entirely sure what it does, going off of the name I'd imagine it skips the post simulation, this is a testvar [def: "false"]
+        // r_particle_timescale                  "1.1"   // Speeds up particle simulation, thus making them end sooner, however this causes visual desyncs, most notably with big effects that last a while such as infernus ult. Please tweak this to what you are comfortable with. [def: "1"]
+        cl_aggregate_particles                   "true"  // Doesn't seem to cause any issues but a benchmark proper should be conducted [def: "false"]
+        r_physics_particle_op_spawn_scale        "0"     // Prevents physics-based particle spawns.                          [def: "1"]
+        r_world_wind_strength                    "0"     // Disables wind effects, cosmetic only.                            [def: "40"]
+
+        // ================ Lod & Culling ================
+        sc_allow_dithered_lod                   "false" // Pretty sure this just turns dithering off for when switching between lods. Isn't a big deal [def: "true"]
+        // sc_instanced_mesh_size_cull_bias     "10"    // Bias for size culling of instanced meshes                        [def: "1.5"]
+        citadel_use_pvs_for_players             "true"  // Default culls players when out of view                           [def: "false"]
+        mat_viewportscale                       "0.01"  // Scale down the main viewport I belive this gets overwritten by video.txt [def: "1"]
+        phys_cull_internal_mesh_contacts        "true"  // Don't simulate the bones inside of a mesh.                       [def: "false"]
+        sc_aggregate_bvh_threshold              "128"   // Not fully sure what these do. Don't change them.                 [def: "128"]
+        sc_fade_distance_scale_override         "100"   // Distance objects fade in and out                                 [def: "-1"]
+        sc_instanced_mesh_lod_bias              "0.15"  // Bias for LOD selection of instanced mesh                         [def: "1.25"]
+        sc_instanced_mesh_lod_bias_shadow       "0.10"  // Bias for LOD selection of instanced meshes in shadowmaps         [def: "1.75"]
+        sc_instanced_mesh_motion_vectors        "0"     // Set 1 if you use motion blur                                     [def: "1"]
+        sc_instanced_mesh_size_cull_bias_shadow "10"    // Bias for size culling instanced meshes in shadowmaps             [def: "2"]
+        sc_layer_batch_threshold                "128"   // Not fully sure what these do. Don't change them.                 [default: "128"]
+        sc_layer_batch_threshold_fullsort       "80"    // Not sure what these do. Jasper said to leave them at default     [def: "80"]
+        sc_screen_size_lod_scale_override       "0.5"   // Controls LOD scale. Lower values will have less polys            [def: "-1"]
+        skeleton_instance_lod_optimization      "false" // Compute LOD mask internally like since 2016, i.e. force all LOD groups' bones to compute [def: "false"]
+
+        // ================ Rendering Stuff ================
+        r_citadel_gpu_culling          "true"  // The game barely uses the gpu so this is a win                    [def: "true"]
+        r_citadel_gpu_culling_two_pass "false" // Assuming that this is culling passes this should be faster       [def: "true"]
+        r_frame_sync_enable            "false" // No documentation, not sure if this does anything                 [def: "true"]
+        r_force_zprepass               "0"     // 0: Force z prepass off. 1: Force on. -1: Don't force             [def: "-1"]
+        // With my understanding of how zprepasses work this should reduce cpu usage if set to zero, but that's under the assumption that valve's implementation isn't properly optimized. Please play with this. Your mileage may vary.
+        r_vma_defrag_algorithm                             "0"     // Should speed up vulkan defragging, which could increase performance if you're  getting bad performance the longer a match goes on [def: "1"]
+        rtx_dynamic_blas                                   "false" // Don't think that raytracing is used, but I'm making sure         [def: "true"]
+        rtx_dynamic_blas_caching                           "false" //                                                                  [def: "true"]
+        rtx_force_default_hitgroup                         "true"  //                                                                  [def: "false"]
+        rtx_texture_resolution                             "64"    //                                                                  [def: "true"]
+        citadel_video_preset                               "2"     // Rendering performance level. min 0, max 3                        [def: "3"]
+        // sc_aggregate_indirect_draw_compaction_threshold "1"     // Need to test                                                   [def: "8"]
+        sc_instanced_mesh_opaque_fade                      "false" // Fade meshes? NAH                                                 [def: "true"]
+        sc_aggregate_render_mesh_shader                    "false" // Using mesh shaders if available instead of drawcalls. Should be cheaper [def: "true"]
+        sc_aggregate_rtproxy_instanced_geo                 "false" //
+        sc_aggregate_rtproxy_unique_geo                    "false" //
+        sc_allow_dithered_lod                              "false" //
 
 
-// =============== No Clue What These do But it's Probably Important. ===============
-//If you test these please report to me on your findings 
-//r_pipeline_stats_flush_before_sleeping true
-//r_pipeline_stats_present_flush true
-//r_wait_on_present true
+        // ================ Misc ================
+        cl_frametime_summary_report_detailed              "false"  // Might cause issues for devs but we shouldn't need this           [def: "true"]
+        citadel_perf_interval_report_s                    "100000" // The interval that we record performance stats to the log at measured in seconds [def: "60"]
+        disable_source_soundscape_trace                   "true"   // Bypasses lookup of soundscapes for indvidual audio sources when enabled. [def: "false"]
+        cc_captiontrace                                   "0"      // Show missing closecaptions (0 = no, 1 = devconsole, 2 = show in hud) [def: "1"]
+        r_particle_model_new                              "false"  // Jasper stated that these variables aren't used by deadlock so I'm disabling them to be safe :steam_happy:    [def: "false"]
+        r_particle_model_new8                             "false"  // Jasper stated that these variables aren't used by deadlock so I'm disabling them to be safe :steam_happy:    [def: "true"]
+        r_pixelvisibility_partial                         "false"  // As far as I am aware this disables the pixel visibility system which should reduce visual fidelity but saves you from drawing a ray (I THINK) [def: "true"]
+        // r_pipeline_stats_use_flush_api                 "false"  // Experimental: Set to 1 to use the ID3D11DeviceContext11::Flush() to flush the GPU pipeline instead of queries. [def: "true"]
+        r_skip_precache_validation_check                  "true"   // I believe this checks to see if things are properly cached in a debug context, which we shouldn't need   [def: "false"]
+        cl_batch_entity_list_ops_during_latch             "true"   // Batch entity list adds / removes while latching interpolated variables to avoid mutex contention.        [def: "false"]
+        cl_interp_parallel                                "true"   // Run interpolation in parallel for entities with no children.     [def: "false"]
+        cl_modifier_parallel_gather_status_effect_updates "true"   // Not sure                                                         [def: "false"]
+        cl_phys_assume_fixed_tick_interval                "false"  // Assume the client uses a fixed tickrate like the server (which may not always be true)                   [def: "true"]
+        engine_max_ticks_to_simulate                      "2"      // Max number of ticks to simulate per frame, after which simulation will start to slow down compared to real time. [def: "-1"]
+        nav_obstruction_async_update                      "true"   // Not fully sure but async good wowie                              [def: "false"]
+        parallel_perform_invalidate_physics               "true"   // Not sure                                                         [def: "false"]
+        r_async_compute_fog                               "true"   // Just whether to asyncroniously render fog                        [def: "false"]
+        r_citadel_depth_prepass_dynamic_objects           "false"  // Should be not prepassing entities that move                      [def: "true"]
+        r_low_latency                                     "1"      // This acts as the convar which enables low latency, hardware dependent    [def: "1"]
+        r_renderdoc_auto_shader_pdbs                      "false"  // Automatically generate shader debug info on capture.             [def: "true"]
+        save_parallel                                     "true"   // Absolutely no idea but typically paralell processing is good.    [def: "false"]
+        sc_force_materials_batchable                      "true"   // I would imagine this functions as the variable is named.         [def: "false"]
+        r_max_portal_render_targets                       "2"      // Maxium number of Doorman doors to allow rendering.               [def: "0"]
+        // ^ This will cause visual bugs when set to 1, either set it to 2 or 0 to disable them.
 
-// ================ Convars You Shouldn't/Can't Mess With But I Want to Maintain the Documentation ================ 
-//r_showdebugoverlays                       "true"          // Shows a ton of debug overlays IT MAKES ME SO HAPPY I LOVE IT     [def: "false"]
-//citadel_first_person                      "true"          // Puts you in first person, messes up character rendering
-//r_extra_render_frames                     "1"             // Setting this to anything above 0 causes issues with latency. negative values cause the game to crash. [def: "0"]
-//cl_particle_max_count                     "1500"          // Maximum allowed particles. Setting it too low will cause issues. With flooding from the console.  [def: "0"]
-//cl_phys_enabled                           "false"         // You can disable physics and might see an improvement in framerate, however a lot will be buggy.   [def: "true"]
-gpu_level                                   "1"             // GPU level literally doesn't matter, gets set to 2 in the engine
-r_citadel_npr_force_solid_outline           "false"         // Causes odd visual bugs with dragons and neutrals when set to true    [def: "false"]
-r_citadel_npr_outlines                      "false"         // Enable outlines on enemy players.                                [def: "true"]
-r_citadel_npr_outlines_max_dist             "1"             // Limits outline distance to reduce unnecessary processing.        [def: "1000"]
-r_citadel_selection_outline2_alpha          "0.2"           // Outlines on enemy players and abilities on a scale of 0-1.       [def: "0.8"]
-r_drawskybox                                "true"          // Can't be changed anymore                                             [def: "true"]
-//sc_aggregate_gpu_culling_show_culled      "true"          // Debug I think, doesn't seem to do anything                     [def: "false"]
-//sc_aggregate_render_mesh_shader           "false"         // Using mesh shaders if available instead of drawcalls.          [def: "true"]
-//citadel_damage_text_show_effectiveness    "true"          // This is supposed to show if your target has any spirit/bullet resist, but seems to be broken rn. [def: "false"]
-//phys_batch_ray_test                       "16"            // Don't know what this does? shouldn't be needed deadlock doesn't have many physics objects  [def: "0"]
-//panorama_worldpanel_update_culling        "true"          // Messes with health bar rendering, the information will be inaccurate unless close to the target if set to true. It is weird.       [def: "false"]
-//r_draw_first_tri_only                     "true"          // Only draw the first triangle. Only works on dx11, causes issues with every playermodel and the hud for some reason [def: "false"]
-//sc_disable_procedural_layer_rendering     "false"         // Disables rendering, ie the screen is black.          [def: "false"]
-//sc_throw_away_all_layers                  "true"          // Disables rendering, ie the screen is black.          [def: "false"]
-//sc_skip_traversal                         "true"          // Disables rendering, ie the screen is black.          [def: "false"]
-//sc_aggregate_show_outside_vis             "true"          // This makes the entire map stop rendering             [def: "false"]
+        // ================ Grass ================
+        r_grass_end_fade   "0" // When to cull grass when far                                      [def: "300"]
+        r_grass_quality    "0" // Quality of the grass                                             [def: "2"]
+        r_grass_start_fade "0" // When to cull grass when it's close I think                       [def: "0"]
 
-//  ---Credits---
-//  Major thanks to all of these individuals from the bottom of my heart. They are all lovely.
-//- Sqooky:             I am the primary developer and maintainer of the project, but without everyone else here this project would not be maintained to this degree
-//- JasperP:            My personal hero.  
-//- Artemon121:         Made the Citadel cvar unhider, which helped Abdalla fetch cvars and test in-game.  
-//- Boot:               Provided the csm cvars which had a notable performance improvement.  
-//- Brullee:            Removed fake cvars, redundant commands, added cvarlist.md, and reformatted config  
-//- Dacooder:           Made a wonderful video highlighting me and the config.  
-//- Kaizuchaneru:       While not directly invovled in the deveopment, they tested most cvars  
-//- Kin:                Did an insane amount of benchmarking unprompted.  
-//- Maihdenless:        Started the original OptimisationLock & its Discord.  
-//- Piggy:              Let me mirror his config.  
-//- Soulx:              Gave me five dollars and told me about spirolactone (fucking sick I love you)
-//- Tamara Mochaccina:  Contributed vindicta scope fix and the fog fix.  
+        // ================ Creep AI ================
+        ai_strong_optimizations_no_checkstand "1"     // Not fully sure what exactly this does, but I would imagine given the name of the convar it optimizes ai. [def: "0"]
+        citadel_npc_force_animate_every_tick  "false" // Don't change this, it does what it says on the tin.              [def: "true"]
+        cl_simulate_dormant_entities          "false" // Based on the name I would imagine it does what it says.          [def: "true"]
 
-// Cool people I've met because of this project who I want to thank anyway
-//- 6Daves
-//- Achira
-//- Anartoast
-//- Boot
-//- GoreDaughter
-//- Jaden
-//- Jasper
-//- Jb
-//- Kin
-//- Krisha
-//- Masteroms
-//- PeachCebo
-//- Tamara Mochaccina
-//- And you, thank you for using this and making my day <3. Please take care of yourselves.
-// --------------------------------- END OF CONFIG OptimizationLock -- ver. 2.4.1 ------------------------------- \\
+        // ================ Audio ================
+        audio_enable_vmix_mastering           "false" // Whether the engine uses vmix to master the audio, might be a dev command [def: "true"]
+        snd_mixahead                          "0.05"  // Adds some latency that shouldn't be percivable to save cpu       [def: "0.001"]
+        snd_occlusion_bounces                 "0"     // Limits audio occlusion to save cpu                               [def: "1"]
+        snd_occlusion_rays                    "0"     // Occlusion bounces, this effectively disables them.               [def: "4"]
+        snd_soundmixer_version                "1"     // [def: "2"]
+        snd_steamaudio_reverb_order_rendering "0"     // The amount of directional detail in the rendered audio by Steam Audio. [def: "0"]
+        snd_ui_positional                     "false" // Disables positional audio to save cpu                            [def: "true"]
+        snd_steamaudio_num_threads            "4"     // Audio thread count                                               [def: "4"]
+        // README This ^ probably depends on how good your cpu is, the better it is the more threads you can allow
+
+        // ================ Csm Shadows. ================
+        // According to jasper these shouldn't do anything, but I'm keeping them because they seemed to provide a performance increase with them disabled
+        // I need to do benchmarks of the config with and without these commands, however I am LAZY
+        csm_cascade0_override_dist               "0"     // All of these commands should reduce shadow quality.
+        csm_cascade1_override_dist               "0"     // All of these commands should reduce shadow quality.
+        csm_cascade2_override_dist               "0"     // All of these commands should reduce shadow quality.
+        csm_cascade3_override_dist               "0"     // All of these commands should reduce shadow quality.
+        csm_max_dist_between_caster_and_receiver "0"     // All of these commands should reduce shadow quality.
+        csm_max_num_cascades_override            "0"     // All of these commands should reduce shadow quality.
+        csm_max_shadow_dist_override             "1"     // All of these commands should reduce shadow quality.
+        csm_max_visible_dist                     "0"     // All of these commands should reduce shadow quality.
+        csm_res_override_0                       "1"     // All of these commands should reduce shadow quality.
+        csm_res_override_1                       "1"     // All of these commands should reduce shadow quality.
+        csm_res_override_2                       "1"     // All of these commands should reduce shadow quality.
+        csm_res_override_3                       "1"     // All of these commands should reduce shadow quality.
+        csm_viewmodel_shadows                    "false" // All of these commands should reduce shadow quality.
 
 
+        // =============== No Clue What These do But it's Probably Important. ===============
+        //If you test these please report to me on your findings
+        // r_pipeline_stats_flush_before_sleeping "true"
+        // r_pipeline_stats_present_flush         "true"
+        // r_wait_on_present                      "true"
 
-// =============== Cvars in Testing :D =============== 
-//citadel_radial_distortion                 "1"    // Doesn't seem to do anything :(, here's what it's supposed to do: 0: Off 1: Distorts the visible distribution of arcs based on the mouse pointer. [def: "0"]
-//cl_fasttempentcollision                   "20"
-//citadel_camera_hard_trace_radius          "32"        //put under camera tweaks :D
-//citadel_fibonnaci_sphere_trace_los_max    "32"        //put under camera tweaks :D
-//cam_collision                             "0"
-//mat_shading_complexity_max_register_count "8"
-//hud_fastswitch                            "0"
-//panorama_transition_time_factor           "0"
-//panorama_disable_render_target_cache      "true"
-//r_skip_precache_validation_check          "true"
-//cl_skip_update_animations                 "true"
-//multigpu_skip_semaphores                  "true"
-//multigpu_skip_transfers                   "true"
-//panorama_skip_composition_layer_content_paint "true"
-//panorama_skip_compo                       "true"
-//r_draw_first_tri_only                     "true"
-//r_frame_sync_enable                       "true"
-//r_nearz                                   "20"
-//r_particle_explicit_fetch                 "true"
-//r_citadel_distancefield_max_distance      "16"            // Doesn't seem to do anything, or if it does it is overwritten. [def: "2048"]
-//r_citadel_distancefield_min_screen_space_size "99"            // Same as above                                                    [def: "0.015"]
+        // ================ Convars You Shouldn't/Can't Mess With But I Want to Maintain the Documentation ================
+        // r_showdebugoverlays                    "true"  // Shows a ton of debug overlays IT MAKES ME SO HAPPY I LOVE IT     [def: "false"]
+        // citadel_first_person                   "true"  // Puts you in first person, messes up character rendering
+        // r_extra_render_frames                  "1"     // Setting this to anything above 0 causes issues with latency. negative values cause the game to crash. [def: "0"]
+        // cl_particle_max_count                  "1500"  // Maximum allowed particles. Setting it too low will cause issues. With flooding from the console.  [def: "0"]
+        // cl_phys_enabled                        "false" // You can disable physics and might see an improvement in framerate, however a lot will be buggy.   [def: "true"]
+        gpu_level                                 "1"     // GPU level literally doesn't matter, gets set to 2 in the engine
+        r_citadel_npr_force_solid_outline         "false" // Causes odd visual bugs with dragons and neutrals when set to true    [def: "false"]
+        r_citadel_npr_outlines                    "false" // Enable outlines on enemy players.                                [def: "true"]
+        r_citadel_npr_outlines_max_dist           "1"     // Limits outline distance to reduce unnecessary processing.        [def: "1000"]
+        r_citadel_selection_outline2_alpha        "0.2"   // Outlines on enemy players and abilities on a scale of 0-1.       [def: "0.8"]
+        r_drawskybox                              "true"  // Can't be changed anymore                                             [def: "true"]
+        // sc_aggregate_gpu_culling_show_culled   "true"  // Debug I think, doesn't seem to do anything                     [def: "false"]
+        // sc_aggregate_render_mesh_shader        "false" // Using mesh shaders if available instead of drawcalls.          [def: "true"]
+        // citadel_damage_text_show_effectiveness "true"  // This is supposed to show if your target has any spirit/bullet resist, but seems to be broken rn. [def: "false"]
+        // phys_batch_ray_test                    "16"    // Don't know what this does? shouldn't be needed deadlock doesn't have many physics objects  [def: "0"]
+        // panorama_worldpanel_update_culling     "true"  // Messes with health bar rendering, the information will be inaccurate unless close to the target if set to true. It is weird.       [def: "false"]
+        // r_draw_first_tri_only                  "true"  // Only draw the first triangle. Only works on dx11, causes issues with every playermodel and the hud for some reason [def: "false"]
+        // sc_disable_procedural_layer_rendering  "false" // Disables rendering, ie the screen is black.          [def: "false"]
+        // sc_throw_away_all_layers               "true"  // Disables rendering, ie the screen is black.          [def: "false"]
+        // sc_skip_traversal                      "true"  // Disables rendering, ie the screen is black.          [def: "false"]
+        // sc_aggregate_show_outside_vis          "true"  // This makes the entire map stop rendering             [def: "false"]
 
-        "rate"
+        //  ---Credits---
+        //  Major thanks to all of these individuals from the bottom of my heart. They are all lovely.
+        //- Sqooky:             I am the primary developer and maintainer of the project, but without everyone else here this project would not be maintained to this degree
+        //- JasperP:            My personal hero.
+        //- Artemon121:         Made the Citadel cvar unhider, which helped Abdalla fetch cvars and test in-game.
+        //- Boot:               Provided the csm cvars which had a notable performance improvement.
+        //- Brullee:            Removed fake cvars, redundant commands, added cvarlist.md, and reformatted config
+        //- Dacooder:           Made a wonderful video highlighting me and the config.
+        //- Kaizuchaneru:       While not directly invovled in the deveopment, they tested most cvars
+        //- Kin:                Did an insane amount of benchmarking unprompted.
+        //- Maihdenless:        Started the original OptimisationLock & its Discord.
+        //- Piggy:              Let me mirror his config.
+        //- Soulx:              Gave me five dollars and told me about spirolactone (fucking sick I love you)
+        //- Tamara Mochaccina:  Contributed vindicta scope fix and the fog fix.
+
+        // Cool people I've met because of this project who I want to thank anyway
+        //- 6Daves
+        //- Achira
+        //- Anartoast
+        //- Boot
+        //- GoreDaughter
+        //- Jaden
+        //- Jasper
+        //- Jb
+        //- Kin
+        //- Krisha
+        //- Masteroms
+        //- PeachCebo
+        //- Tamara Mochaccina
+        //- And you, thank you for using this and making my day <3. Please take care of yourselves.
+        // --------------------------------- END OF CONFIG OptimizationLock -- ver. 2.4.1 ------------------------------- \\
+
+
+
+        // =============== Cvars in Testing :D ===============
+        // citadel_radial_distortion                     "1" // Doesn't seem to do anything :(, here's what it's supposed to do: 0: Off 1: Distorts the visible distribution of arcs based on the mouse pointer. [def: "0"]
+        // cl_fasttempentcollision                       "20"
+        // citadel_camera_hard_trace_radius              "32" //put under camera tweaks :D
+        // citadel_fibonnaci_sphere_trace_los_max        "32" //put under camera tweaks :D
+        // cam_collision                                 "0"
+        // mat_shading_complexity_max_register_count     "8"
+        // hud_fastswitch                                "0"
+        // panorama_transition_time_factor               "0"
+        // panorama_disable_render_target_cache          "true"
+        // r_skip_precache_validation_check              "true"
+        // cl_skip_update_animations                     "true"
+        // multigpu_skip_semaphores                      "true"
+        // multigpu_skip_transfers                       "true"
+        // panorama_skip_composition_layer_content_paint "true"
+        // panorama_skip_compo                           "true"
+        // r_draw_first_tri_only                         "true"
+        // r_frame_sync_enable                           "true"
+        // r_nearz                                       "20"
+        // r_particle_explicit_fetch                     "true"
+        // r_citadel_distancefield_max_distance          "16" // Doesn't seem to do anything, or if it does it is overwritten. [def: "2048"]
+        // r_citadel_distancefield_min_screen_space_size "99" // Same as above                                                    [def: "0.015"]
+
+        rate
         {
-            "min"       "98304"
-            "default"   "786432"
-            "max"       "1000000"
+            min     "98304"
+            default "786432"
+            max     "1000000"
         }
-        "sv_minrate"    "98304"
-        "sv_maxunlag"   "0.500"
-        "sv_maxunlag_player" "0.200"
-        "sv_lagcomp_filterbyviewangle" "false"
+        sv_minrate                   "98304"
+        sv_maxunlag                  "0.500"
+        sv_maxunlag_player           "0.200"
+        sv_lagcomp_filterbyviewangle "false"
 
         // Spew warning when adding/removing classes to/from the top of the hierarchy
-        "panorama_classes_perf_warning_threshold_ms" "0.75"
+        panorama_classes_perf_warning_threshold_ms "0.75"
 
         // Panorama - enable minidumps on JS exceptions
-        "panorama_js_minidumps" "1"
+        panorama_js_minidumps "1"
         // Enable the render target cache optimization.
-        "panorama_disable_render_target_cache" "0"
+        panorama_disable_render_target_cache "0"
 
         // Enable the composition layer optimization
-        "panorama_skip_composition_layer_content_paint" "1"
+        panorama_skip_composition_layer_content_paint "1"
 
         // too expensive (500MB+) to load this
-        "snd_steamaudio_load_reverb_data" "0"
-        "snd_steamaudio_load_pathing_data" "0"
+        snd_steamaudio_load_reverb_data  "0"
+        snd_steamaudio_load_pathing_data "0"
 
         // Steam Audio project specific convars
-        "snd_steamaudio_enable_custom_hrtf"     "0"
-        "snd_steamaudio_active_hrtf"            "0"
-        "snd_steamaudio_reverb_update_rate"     "10.0"
-        "snd_steamaudio_ir_duration"            "1.0"
-        "snd_steamaudio_enable_pathing"         "0"
-        "snd_steamaudio_invalid_path_length"    "0.0"
-        "cl_disconnect_soundevent"              "citadel.convar.stop_all_game_layer_soundevents"
-        "snd_event_browser_default_stack"       "citadel_default_3d"
+        snd_steamaudio_enable_custom_hrtf  "0"
+        snd_steamaudio_active_hrtf         "0"
+        snd_steamaudio_reverb_update_rate  "10.0"
+        snd_steamaudio_ir_duration         "1.0"
+        snd_steamaudio_enable_pathing      "0"
+        snd_steamaudio_invalid_path_length "0.0"
+        cl_disconnect_soundevent           "citadel.convar.stop_all_game_layer_soundevents"
+        snd_event_browser_default_stack    "citadel_default_3d"
 
         // voip
-        "voice_in_process"                      "1"
+        voice_in_process "1"
 
         // Sound debugging
-        //"snd_report_audio_nan" "1"
+        // snd_report_audio_nan "1"
 
         // Audio system settings
-        "snd_sos_max_event_base_depth" "10"
-        "sos_use_guid_filter" "1"
+        snd_sos_max_event_base_depth "10"
+        sos_use_guid_filter          "1"
 
-        "voice_always_sample_mic"
+        voice_always_sample_mic
         {
-            "version"   "2"
-            "default"   "0"
+            version "2"
+            default "0"
         }
 
-        "reset_voice_on_input_stallout"         "0"
-        "voice_input_stallout"                  "0.5"
-        "cl_usesocketsforloopback" "1"
-        "cl_poll_network_early" "0"
+        reset_voice_on_input_stallout "0"
+        voice_input_stallout          "0.5"
+        cl_usesocketsforloopback      "1"
+        cl_poll_network_early         "0"
 
         // Perf/Parallelism
-        "iv_parallel_restore" "1"
+        iv_parallel_restore "1"
 
         // For perf reasons, since we don't use source-based DSP:
-        "disable_source_soundscape_trace"       "1"
+        disable_source_soundscape_trace "1"
 
         // Networking - Induced latency (pred offset)
-        "cl_tickpacket_recvmargin_desired" "5"                  // 5 ms base, min. floor for protecting against thrashing the queue
-        "cl_tickpacket_desired_queuelength" "0"                 // 0 = attempt to always reach the queue's min floor
-        "cl_async_usercmd_send_disabled_recvmargin_min" "0.5"   // Additional frame since we do not use the async usercmd send (potentially unneccessary)
-        "cl_clock_buffer_ticks" "1"
-        "cl_interp_ratio" "0"
-        "cl_async_usercmd_send" "false"
+        cl_tickpacket_recvmargin_desired              "5"   // 5 ms base, min. floor for protecting against thrashing the queue
+        cl_tickpacket_desired_queuelength             "0"   // 0 = attempt to always reach the queue's min floor
+        cl_async_usercmd_send_disabled_recvmargin_min "0.5" // Additional frame since we do not use the async usercmd send (potentially unneccessary)
+        cl_clock_buffer_ticks                         "1"
+        cl_interp_ratio                               "0"
+        cl_async_usercmd_send                         "false"
 
-        "fps_max_ui"    "120"
+        fps_max_ui "120"
 
-        "in_button_double_press_window" "0.3"
+        in_button_double_press_window "0.3"
 
         // Convars that control spatialization of UI audio.
-        "snd_ui_positional"                             "false"
-        "snd_ui_spatialization_spread"                  "2.4"
+        snd_ui_positional            "false"
+        snd_ui_spatialization_spread "2.4"
 
         // sound volume rate change limiting
-        "snd_envelope_rate"                             "100.0"
-        "snd_soundmixer_update_maximum_frame_rate"      "0"
+        snd_envelope_rate                        "100.0"
+        snd_soundmixer_update_maximum_frame_rate "0"
 
         //don't let people mess with speaker config settings.
-        "speaker_config"
+        speaker_config
         {
-            "min"       "0"
-            "default"   "0"
-            "max"       "2"
+            min     "0"
+            default "0"
+            max     "2"
         }
 
-        "cq_buffer_bloat_msecs_max" "120"
+        cq_buffer_bloat_msecs_max "120"
 
-        "snd_soundmixer"                        "Default_Mix"
-        "cloth_filter_transform_stateless" "0"
+        snd_soundmixer                   "Default_Mix"
+        cloth_filter_transform_stateless "0"
 
-        "cl_joystick_enabled" "1"
-        "panorama_joystick_enabled" "1"
+        cl_joystick_enabled       "1"
+        panorama_joystick_enabled "1"
 
-        "snd_event_browser_focus_events" "true"
+        snd_event_browser_focus_events "true"
 
-        "cl_max_particle_pvs_aabb_edge_length" "100"
+        cl_max_particle_pvs_aabb_edge_length "100"
 
         // Allow aggregation of particles (for perf)
-        //"cl_aggregate_particles" "true"
+        // cl_aggregate_particles "true"
 
-        "citadel_enable_vdata_sound_preload"    "true"
-        "r_add_views_in_pre_output"             "1"
+        citadel_enable_vdata_sound_preload "true"
+        r_add_views_in_pre_output          "1"
 
 
 
@@ -1113,14 +1113,10 @@ r_drawskybox                                "true"          // Can't be changed 
 
     Memory
     {
-        "EstimatedMaxCPUMemUsageMB" "1"
-        "EstimatedMinGPUMemUsageMB" "1"
+        EstimatedMaxCPUMemUsageMB "1"
+        EstimatedMinGPUMemUsageMB "1"
 
-        "ShowInsufficientPageFileMessageBox" "1"
-        "ShowLowAvailableVirtualMemoryMessageBox" "1"
+        ShowInsufficientPageFileMessageBox      "1"
+        ShowLowAvailableVirtualMemoryMessageBox "1"
     }
 }
-
-
-
-

--- a/boot's maxium fps config/gameinfo.gi
+++ b/boot's maxium fps config/gameinfo.gi
@@ -1,6 +1,6 @@
 //      If you would like to donate as a means of showing thanks I have a kofi.     \\
 //      https://ko-fi.com/sqooky                                                    \\
-//           ...       ....       
+//           ...       ....
 // ..................................................
 // ...................+%%%%=.........................
 // .................=%......%%.......................
@@ -33,60 +33,60 @@
 // As much as I would love to say I did this alone, I did not. These are the amazing people who deserve as much praise as I, if not more
 //- Sqooky:             I am the primary developer and maintainer of the project, but without everyone else here this project would not be maintained to this degree
 //- JasperP:            My personal hero.
-//- Artemon121:         Made the Citadel cvar unhider, which helped Abdalla fetch cvars and test in-game.  
-//- Boot:               Provided the csm cvars which had a notable performance improvement.  
-//- Brullee:            Removed fake cvars, redundant commands, added cvarlist.md, and reformatted config.  
-//- Dacooder:           Made a wonderful video highlighting me and the config.  
-//- Kaizuchaneru:       While not directly invovled in the deveopment, they tested most cvars.  
-//- Kin:                Did an insane amount of benchmarking unprompted.  
-//- Maihdenless:        Started the original OptimisationLock & its Discord.  
-//- Piggy:              Let me mirror his config.  
+//- Artemon121:         Made the Citadel cvar unhider, which helped Abdalla fetch cvars and test in-game.
+//- Boot:               Provided the csm cvars which had a notable performance improvement.
+//- Brullee:            Removed fake cvars, redundant commands, added cvarlist.md, and reformatted config.
+//- Dacooder:           Made a wonderful video highlighting me and the config.
+//- Kaizuchaneru:       While not directly invovled in the deveopment, they tested most cvars.
+//- Kin:                Did an insane amount of benchmarking unprompted.
+//- Maihdenless:        Started the original OptimisationLock & its Discord.
+//- Piggy:              Let me mirror his config.
 //- Soulx:              Gave me five dollars and told me about spirolactone (fucking sick I love you).
-//- Tamara Mochaccina:  Contributed vindicta scope fix and the fog fix.  
+//- Tamara Mochaccina:  Contributed vindicta scope fix and the fog fix.
 
-"GameInfo"
+GameInfo
 {
     game        "citadel"
     title       "Citadel"
-    type        multiplayer_only
-    nomodels 1
-    nohimodel 1
-    nocrosshair 0
+    type        "multiplayer_only"
+    nomodels    "1"
+    nohimodel   "1"
+    nocrosshair "0"
     hidden_maps
     {
-        "test_speakers"         1
-        "test_hardware"         1
+        test_speakers "1"
+        test_hardware "1"
     }
-    nodegraph 0
-    perfwizard 0
-    tonemapping 0
+    nodegraph   "0"
+    perfwizard  "0"
+    tonemapping "0"
     GameData    "citadel.fgd"
 
     Localize
     {
-        DuplicateTokensAssert   1
-        DisallowTokenContexts   1
+        DuplicateTokensAssert "1"
+        DisallowTokenContexts "1"
     }
 
     SupportedLanguages
     {
-        "brazilian" "3"
-        "czech" "3"
-        "english" "3"
-        "french" "3"
-        "german" "3"
-        "italian" "3"
-        "indonesian" "3"
-        "japanese" "3"
-        "koreana" "3"
-        "latam" "3"
-        "polish" "3"
-        "russian" "3"
-        "schinese" "3"
-        "spanish" "3"
-        "thai" "3"
-        "turkish" "3"
-        "ukrainian" "3"
+        brazilian  "3"
+        czech      "3"
+        english    "3"
+        french     "3"
+        german     "3"
+        italian    "3"
+        indonesian "3"
+        japanese   "3"
+        koreana    "3"
+        latam      "3"
+        polish     "3"
+        russian    "3"
+        schinese   "3"
+        spanish    "3"
+        thai       "3"
+        turkish    "3"
+        ukrainian  "3"
     }
 
     FileSystem
@@ -108,16 +108,16 @@
         {
             // These are optional language paths. They must be mounted first, which is why there are first in the list.
             // *LANGUAGE* will be replaced with the actual language name. If not running a specific language, these paths will not be mounted
-            Game_Language       citadel_*LANGUAGE*
+            Game_Language "citadel_*LANGUAGE*"
 
             // These are optional low-violence paths. They will only get mounted if you're in a low-violence mode.
-            Game_LowViolence    citadel_lv
+            Game_LowViolence "citadel_lv"
 
-            Mod                 citadel
-            Write               citadel
-            Game                citadel/addons
-            Game                citadel
-            Game                core
+            Mod   "citadel"
+            Write "citadel"
+            Game  "citadel/addons"
+            Game  "citadel"
+            Game  "core"
         }
     }
 
@@ -125,92 +125,92 @@
     {
         RenderModes
         {
-            game Default
-            game Forward
-            game Deferred
-            game Outline
-            game Depth
-            game FrontDepth
+            game "Default"
+            game "Forward"
+            game "Deferred"
+            game "Outline"
+            game "Depth"
+            game "FrontDepth"
 
-            dev ToolsVis // Visualization modes for all shaders (lighting only, normal maps only, etc.)
-            dev ToolsWireframe // This should use the ToolsVis mode above instead of being its own mode\
+            dev "ToolsVis"       // Visualization modes for all shaders (lighting only, normal maps only, etc.)
+            dev "ToolsWireframe" // This should use the ToolsVis mode above instead of being its own mode\
 
-            tools ToolsUtil // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
+            tools "ToolsUtil" // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
         }
     }
 
     MaterialEditor
     {
-        "DefaultShader" "environment_texture_set"
+        DefaultShader "environment_texture_set"
     }
 
     NetworkSystem
     {
         BetaUniverse
         {
-            FakeLag         0
-            FakeLoss        0
-            //FakeReorderPct 0.05
-            //FakeReorderDelay 10
-            //FakeJitter "low"
+            FakeLag             "0"
+            FakeLoss            "0"
+            // FakeReorderPct   "0.05"
+            // FakeReorderDelay "10"
+            // FakeJitter       "low"
             // Turning off fake jitter for now while I work on making the CQ totally solid
-            FakeReorderPct 0
-            FakeReorderDelay 0
-            FakeJitter "off"
+            FakeReorderPct   "0"
+            FakeReorderDelay "0"
+            FakeJitter       "off"
         }
 
-        "UseSerializedEntityPool" "1"
-        "SkipRedundantChangeCallbacks"  "1"
+        UseSerializedEntityPool      "1"
+        SkipRedundantChangeCallbacks "1"
     }
 
     RenderSystem
     {
-        IndexBufferPoolSizeMB                       "32"
-        VertexBufferPoolSizeMB                      "32"
-        UseReverseDepth                             "1"
-        Use32BitDepthBuffer                         "0"
-        Use32BitDepthBufferWithoutStencil           "0"
-        SwapChainSampleableDepth                    "1"
-        VulkanMutableSwapchain                      "1"
-        "LowLatency"                                "1"
-        "VulkanOnly_Linux"                          "1"
-        "VulkanRequireSubgroupWaveOpSupport"        "1"
-        "VulkanRequireDescriptorIndexing"           "1" [ !$OSX ]
-        "VulkanSteamShaderCache" "1"
-        "VulkanSteamAppShaderCache" "1"
-        "VulkanSteamDownloadedShaderCache" "1"
-        "VulkanAdditionalShaderCache" "vulkan_shader_cache.foz"
-        "VulkanStagingPMBSizeLimitMB" "384"
-        "GraphicsPipelineLibrary"   "1"
-        "VulkanOnlyTestProbability" "0"
-        "VulkanDefrag"              "1"
-        "MinStreamingPoolSizeMB"    "1024"
-        "MinStreamingPoolSizeMBTools" "2048"
+        IndexBufferPoolSizeMB              "32"
+        VertexBufferPoolSizeMB             "32"
+        UseReverseDepth                    "1"
+        Use32BitDepthBuffer                "0"
+        Use32BitDepthBufferWithoutStencil  "0"
+        SwapChainSampleableDepth           "1"
+        VulkanMutableSwapchain             "1"
+        LowLatency                         "1"
+        VulkanOnly_Linux                   "1"
+        VulkanRequireSubgroupWaveOpSupport "1"
+        VulkanRequireDescriptorIndexing    "\"1\" [ !$OSX ]"
+        VulkanSteamShaderCache             "1"
+        VulkanSteamAppShaderCache          "1"
+        VulkanSteamDownloadedShaderCache   "1"
+        VulkanAdditionalShaderCache        "vulkan_shader_cache.foz"
+        VulkanStagingPMBSizeLimitMB        "384"
+        GraphicsPipelineLibrary            "1"
+        VulkanOnlyTestProbability          "0"
+        VulkanDefrag                       "1"
+        MinStreamingPoolSizeMB             "1024"
+        MinStreamingPoolSizeMBTools        "2048"
     }
 
     NVNGX
     {
-        AppID 103371621
-        SupportsDLSS 1
-        ReflexLateWarp 1
+        AppID          "103371621"
+        SupportsDLSS   "1"
+        ReflexLateWarp "1"
     }
 
     Engine2
     {
-        HasModAppSystems 1
-        Capable64Bit 1
-        URLName citadel
+        HasModAppSystems "1"
+        Capable64Bit     "1"
+        URLName          "citadel"
         RenderingPipeline
         {
-            SupportsMSAA 0
-            DistanceField 0
-            AmbientOcclusionProxies 0
+            SupportsMSAA            "0"
+            DistanceField           "0"
+            AmbientOcclusionProxies "0"
         }
-        PauseSinglePlayerOnGameOverlay 1
-        DefensiveConCommands 1
-        DisableLoadingPlaque 1
-        AllowKeyChordBindings 0
-        LightmapUVQuery 0
+        PauseSinglePlayerOnGameOverlay "1"
+        DefensiveConCommands           "1"
+        DisableLoadingPlaque           "1"
+        AllowKeyChordBindings          "0"
+        LightmapUVQuery                "0"
     }
 
     ContentBuilder
@@ -220,70 +220,70 @@
 
     SoundSystem
     {
-        SteamAudioEnabled            "1"
-        WaveDataCacheSizeMB          "256"
-        "UsePlatTime"            "1"
+        SteamAudioEnabled   "1"
+        WaveDataCacheSizeMB "256"
+        UsePlatTime         "1"
     }
     Sounds
     {
-        HierarchicalEncodingFiles    "1"
+        HierarchicalEncodingFiles "1"
     }
 
     ToolsEnvironment
     {
-        "Engine"    "Source 2"
-        "ToolsDir"  "../sdktools"   // NOTE: Default Tools path. This is relative to the mod path.
+        Engine   "Source 2"
+        ToolsDir "../sdktools" // NOTE: Default Tools path. This is relative to the mod path.
     }
 
     pulse
     {
-        "pulse_enabled"                 "1"
+        pulse_enabled "1"
     }
 
     Hammer
     {
-        "CreateRenderClusters"      "1"
-        "DefaultMinDrawVolumeSize"  "2048"
-        "DefaultMinTrianglesPerCluster" "16384"
-        "DefaultPointEntity"    "info_player_start"
-        "DefaultSolidEntity"    "trigger_multiple"
-        "GameFeatureSet"        "Citadel"
-        "LatticeDeformerEnabled"        "1"
-        "LoadScriptEntities" "0"
-        "NavMarkupEntity"       "func_nav_markup"
-        "OverlayBoxSize"            "8"
-        "RenderMode"                "ToolsVis"
-        "ShadowAtlasHeight" "0"
-        "ShadowAtlasWidth" "0"
-        "SteamAudioEnabled"             "1"
-        "SupportsDisplacementMapping" "0"
-        "TileGridBlendDefaultColor" "0 255 0"
-        "TileGridSupportsBlendHeight"   "1"
-        "TileMeshesEnabled"         "1"
-        "TimeSlicedShadowMapRendering" "0"
-        "UseAnalyticGrid" "0"
-        "UsesBakedLighting" "1"
-        "fgd"                   "citadel.fgd"   // NOTE: This is relative to the 'game' path.
+        CreateRenderClusters          "1"
+        DefaultMinDrawVolumeSize      "2048"
+        DefaultMinTrianglesPerCluster "16384"
+        DefaultPointEntity            "info_player_start"
+        DefaultSolidEntity            "trigger_multiple"
+        GameFeatureSet                "Citadel"
+        LatticeDeformerEnabled        "1"
+        LoadScriptEntities            "0"
+        NavMarkupEntity               "func_nav_markup"
+        OverlayBoxSize                "8"
+        RenderMode                    "ToolsVis"
+        ShadowAtlasHeight             "0"
+        ShadowAtlasWidth              "0"
+        SteamAudioEnabled             "1"
+        SupportsDisplacementMapping   "0"
+        TileGridBlendDefaultColor     "0 255 0"
+        TileGridSupportsBlendHeight   "1"
+        TileMeshesEnabled             "1"
+        TimeSlicedShadowMapRendering  "0"
+        UseAnalyticGrid               "0"
+        UsesBakedLighting             "1"
+        fgd                           "citadel.fgd" // NOTE: This is relative to the 'game' path.
     }
 
     SoundTool
     {
-        "DefaultSoundEventType" "src1_3d"
+        DefaultSoundEventType "src1_3d"
 
         SoundEventBaseOptions
         {
-            "Base.Announcer.VO.2d" ""
-            "Base.World.VO.Emitter.3d" ""
-            "Base.Hero.VO.Ping.2d" ""
-            "Base.Hero.VO.2d" ""
-            "Base.Hero.VO.3d" ""
-            "Base.Hero.VO.Ability.3d" ""
-            "Base.Hero.VO.Ultimate.3d" ""
-            "Base.Hero.VO.Dash.3d" ""
-            "Base.Hero.VO.Effort.3d" ""
-            "Base.Hero.VO.Pain.3d" ""
-            "Base.Hero.VO.Melee.3d" ""
-            "Base.Hero.VO.Death.3d" ""
+            Base.Announcer.VO.2d     ""
+            Base.World.VO.Emitter.3d ""
+            Base.Hero.VO.Ping.2d     ""
+            Base.Hero.VO.2d          ""
+            Base.Hero.VO.3d          ""
+            Base.Hero.VO.Ability.3d  ""
+            Base.Hero.VO.Ultimate.3d ""
+            Base.Hero.VO.Dash.3d     ""
+            Base.Hero.VO.Effort.3d   ""
+            Base.Hero.VO.Pain.3d     ""
+            Base.Hero.VO.Melee.3d    ""
+            Base.Hero.VO.Death.3d    ""
         }
     }
 
@@ -298,89 +298,89 @@
         // steps. Additionally this controls which builders are displayed in the hammer build dialog.
         DefaultMapBuilders
         {
-            "bakedlighting" "1" // Enable lightmapping during compile time
-            "envmap"    "0" // turned off since it currently causes an assert and doesn't work due to some build issue
-            "nav"       "1" // Generate nav mesh data
+            bakedlighting "1" // Enable lightmapping during compile time
+            envmap        "0" // turned off since it currently causes an assert and doesn't work due to some build issue
+            nav           "1" // Generate nav mesh data
         }
 
         MeshCompiler
         {
-            OptimizeForMeshlets 1
-            TrianglesPerMeshlet 64  // Maximum valid value currently is 126
-            UseMikkTSpace 1
-            EncodeVertexBuffer 1
-            EncodeVertexBufferVersion 1
-            EncodeVertexBufferLevel 3
-            EncodeIndexBuffer 1
-            SplitDepthStream 1
+            OptimizeForMeshlets       "1"
+            TrianglesPerMeshlet       "64" // Maximum valid value currently is 126
+            UseMikkTSpace             "1"
+            EncodeVertexBuffer        "1"
+            EncodeVertexBufferVersion "1"
+            EncodeVertexBufferLevel   "3"
+            EncodeIndexBuffer         "1"
+            SplitDepthStream          "1"
         }
 
         WorldRendererBuilder
         {
-            VisibilityGuidedMeshClustering      "1"
-            MinimumTrianglesPerClusteredMesh    "8192"
-            MinimumVerticesPerClusteredMesh     "8192"
-            MinimumVolumePerClusteredMesh       "8192"       // ~20x20x20 cube
-            MaxPrecomputedVisClusterMembership  "96"
-            MaxCullingBoundsGroups              "128"
-            UseAggregateInstances               "1"
-            AggregateInstancingMeshlets         "1"
-            BakePropsWithExtraVertexStreams     "1"
+            VisibilityGuidedMeshClustering     "1"
+            MinimumTrianglesPerClusteredMesh   "8192"
+            MinimumVerticesPerClusteredMesh    "8192"
+            MinimumVolumePerClusteredMesh      "8192" // ~20x20x20 cube
+            MaxPrecomputedVisClusterMembership "96"
+            MaxCullingBoundsGroups             "128"
+            UseAggregateInstances              "1"
+            AggregateInstancingMeshlets        "1"
+            BakePropsWithExtraVertexStreams    "1"
         }
 
         BakedLighting
         {
-            Version 4
-            ImportanceVolumeTransitionRegion 512            // distance we transition from high to low resolution charts
+            Version                          "4"
+            ImportanceVolumeTransitionRegion "512" // distance we transition from high to low resolution charts
             LightmapChannels
             {
-                direct_light_shadows 1
-                debug_chart_color 1
-                directional_irradiance_sh2_dc 1
+                direct_light_shadows          "1"
+                debug_chart_color             "1"
+                directional_irradiance_sh2_dc "1"
 
                 directional_irradiance_sh2_r
                 {
-                    CompressedFormat DXT1
+                    CompressedFormat "DXT1"
                 }
 
                 directional_irradiance_sh2_g
                 {
-                    CompressedFormat DXT1
+                    CompressedFormat "DXT1"
                 }
 
                 directional_irradiance_sh2_b
                 {
-                    CompressedFormat DXT1
+                    CompressedFormat "DXT1"
                 }
             }
-            LightmapGutterSize 2 // For bicubic filtering
-            UseStaticLightProbes 0
-            LPVAtlas 1
-            BC6HHueShiftFixup 0 // Causes more artifacts than it solves atm
-            Repack2 1
+            LightmapGutterSize   "2" // For bicubic filtering
+            UseStaticLightProbes "0"
+            LPVAtlas             "1"
+            BC6HHueShiftFixup    "0" // Causes more artifacts than it solves atm
+            Repack2              "1"
         }
 
         SteamAudio
         {
             ReverbDefaults
             {
-                GridSpacing         "3.0"
-                HeightAboveFloor    "1.5"
-                RebakeOption        "0"                     // 0: cleanup, 1: manual, 2: auto
-                NumRays             "32768"
-                NumBounces          "64"
-                IRDuration          "1.0"
-                AmbisonicsOrder     "1"
+                GridSpacing      "3.0"
+                HeightAboveFloor "1.5"
+                RebakeOption     "0" // 0: cleanup, 1: manual, 2: auto
+                NumRays          "32768"
+                NumBounces       "64"
+                IRDuration       "1.0"
+                AmbisonicsOrder  "1"
             }
             PathingDefaults
             {
-                GridSpacing         "3.0"
-                HeightAboveFloor    "1.5"
-                RebakeOption        "0"                     // 0: cleanup, 1: manual, 2: auto
-                NumVisSamples       "1"
-                ProbeVisRadius      "0"
-                ProbeVisThreshold   "0.1"
-                ProbeVisPathRange   "1000.0"
+                GridSpacing       "3.0"
+                HeightAboveFloor  "1.5"
+                RebakeOption      "0" // 0: cleanup, 1: manual, 2: auto
+                NumVisSamples     "1"
+                ProbeVisRadius    "0"
+                ProbeVisThreshold "0.1"
+                ProbeVisPathRange "1000.0"
             }
         }
         SoundStackScripts
@@ -389,776 +389,776 @@
         }
         VisBuilder
         {
-            MaxVisClusters "4096"
+            MaxVisClusters                     "4096"
             PreMergeOpenSpaceDistanceThreshold "128.0"
-            PreMergeOpenSpaceMaxDimension "2048.0"
-            PreMergeOpenSpaceMaxRatio "8.0"
-            PreMergeSmallRegionsSizeThreshold "20.0"
+            PreMergeOpenSpaceMaxDimension      "2048.0"
+            PreMergeOpenSpaceMaxRatio          "8.0"
+            PreMergeSmallRegionsSizeThreshold  "20.0"
         }
 
         VDataLocalization
         {
-            GameOutputPath  "resource/localization/citadel_vdata"
-            TokenPrefix     "Citadel_VData_"
+            GameOutputPath "resource/localization/citadel_vdata"
+            TokenPrefix    "Citadel_VData_"
         }
 
         TextureCompiler
         {
-            //Compressor              "lz4"
-            //CompressMipsOnDisk      "1"
-            //CompressMinRatio        "95"
-            AllowNP2Textures        "1"
+            // Compressor               "lz4"
+            // CompressMipsOnDisk       "1"
+            // CompressMinRatio         "95"
+            AllowNP2Textures            "1"
             AllowPanoramaMipGeneration  "1"
-            //PublicToolsDefaultMaxRes "2048"
+            // PublicToolsDefaultMaxRes "2048"
         }
     }
 
     Source1Import
     {
         // this is just copied from the left4dead3 gameinfo.gi
-        "forcevtxfileupconvert" 1
+        forcevtxfileupconvert "1"
     }
 
     WorldRenderer
     {
-        EnvironmentMaps             1
-        EnvironmentMapFaceSize          256
-        EnvironmentMapRenderSize        1024
-        EnvironmentMapFormat            BC6H
-        EnvironmentMapPreviewFormat         BC6H
-        EnvironmentMapColorSpace        linear
-        EnvironmentMapMipProcessor      GGXCubeMapBlur
+        EnvironmentMaps             "1"
+        EnvironmentMapFaceSize      "256"
+        EnvironmentMapRenderSize    "1024"
+        EnvironmentMapFormat        "BC6H"
+        EnvironmentMapPreviewFormat "BC6H"
+        EnvironmentMapColorSpace    "linear"
+        EnvironmentMapMipProcessor  "GGXCubeMapBlur"
         // Build cubemaps into a cube array instead of individual cubemaps.
-        EnvironmentMapUseCubeArray              1
-        EnvironmentMapCacheSizeTools            300
-        BindlessSceneObjectDesc         CitadelBindlessDesc
-        GrassCastsShadows               0
-        LPVEdgeBlending                         0
+        EnvironmentMapUseCubeArray   "1"
+        EnvironmentMapCacheSizeTools "300"
+        BindlessSceneObjectDesc      "CitadelBindlessDesc"
+        GrassCastsShadows            "0"
+        LPVEdgeBlending              "0"
     }
 
     SceneSystem
     {
-        CMTAtlasHeight 256
-        CMTAtlasWidth 512
-        CSMCascadeResolution 0
-        CharacterDecals 0
-        CubemapFog 0
-        DefaultShadowTextureHeight 0
-        DefaultShadowTextureWidth 0
+        CMTAtlasHeight             "256"
+        CMTAtlasWidth              "512"
+        CSMCascadeResolution       "0"
+        CharacterDecals            "0"
+        CubemapFog                 "0"
+        DefaultShadowTextureHeight "0"
+        DefaultShadowTextureWidth  "0"
 
         // Temp till I can add support in citadel shaders
-        DisableLateAllocatedTransformBuffer 1
-        DynamicShadowResolution 0
-        FogCachedShadowAtlasHeight 0
-        FogCachedShadowAtlasWidth 0
-        FogCachedShadowTileMaxFilterRadius 0
-        FogCachedShadowTileSize 0
-        FrameBufferCopyFormat R11G11B10F
-        GpuLightBinner 1
-        GpuLightBinnerSunLightFastPath 1
-        GpuLightBinnerSupportViewModelCascade 1
-        HDRFrameBuffer 0
-        LayerBatchThresholdFullsort 128
-        MinimumLateAllocatedVertexCacheBufferSizeMB 64
-        NonTexturedGradientFog      0
+        DisableLateAllocatedTransformBuffer         "1"
+        DynamicShadowResolution                     "0"
+        FogCachedShadowAtlasHeight                  "0"
+        FogCachedShadowAtlasWidth                   "0"
+        FogCachedShadowTileMaxFilterRadius          "0"
+        FogCachedShadowTileSize                     "0"
+        FrameBufferCopyFormat                       "R11G11B10F"
+        GpuLightBinner                              "1"
+        GpuLightBinnerSunLightFastPath              "1"
+        GpuLightBinnerSupportViewModelCascade       "1"
+        HDRFrameBuffer                              "0"
+        LayerBatchThresholdFullsort                 "128"
+        MinimumLateAllocatedVertexCacheBufferSizeMB "64"
+        NonTexturedGradientFog                      "0"
 
-        ParticleBufferSize 256
-        PointLightShadowsEnabled 0
-        PunctualContactShadows 0
-        ShadowmapMaxFilterRadius 0
-        SunLightManagerCount 0
-        SunLightManagerCountTools 0
-        SunLightMaxCascadeSize      2
-        SunLightShadowRenderMode    Depth
-        SupportsInstancedFade 1
-        Tonemapping 0
-        TransformTextureRowCount    1024
-        TransformTextureRowCountToolsMode 6144
-        VolumetricFog 0
+        ParticleBufferSize                "256"
+        PointLightShadowsEnabled          "0"
+        PunctualContactShadows            "0"
+        ShadowmapMaxFilterRadius          "0"
+        SunLightManagerCount              "0"
+        SunLightManagerCountTools         "0"
+        SunLightMaxCascadeSize            "2"
+        SunLightShadowRenderMode          "Depth"
+        SupportsInstancedFade             "1"
+        Tonemapping                       "0"
+        TransformTextureRowCount          "1024"
+        TransformTextureRowCountToolsMode "6144"
+        VolumetricFog                     "0"
 
         WellKnownLightCookies
         {
-            "blank" "materials/effects/lightcookies/blank.vtex"
-            "flashlight" "materials/effects/lightcookies/flashlight.vtex"
+            blank      "materials/effects/lightcookies/blank.vtex"
+            flashlight "materials/effects/lightcookies/flashlight.vtex"
         }
 
-        ComputeShaderSkinning 1
+        ComputeShaderSkinning "1"
     }
 
     NavSystem
     {
-        "NavTileSize" "128.0"
-        "NavCellSize" "1.5"
-        "NavCellHeight" "2.0"
+        NavTileSize   "128.0"
+        NavCellSize   "1.5"
+        NavCellHeight "2.0"
 
         // Hull definitions live in scripts/nav_hulls.vdata
         // Preset definitions live in scripts/nav_hulls_presets.vdata
-        "NavHullsPreset" "default"
+        NavHullsPreset "default"
 
-        "NavRegionMinSize" "8"
-        "NavRegionMergeSize" "20"
-        "NavEdgeMaxLen" "1200"
-        "NavEdgeMaxError" "51.0"
-        "NavVertsPerPoly" "4"
-        "NavDetailSampleDistance" "120.0"
-        "NavDetailSampleMaxError" "2.0"
-        "NavSmallAreaOnEdgeRemovalSize" "81.0"
+        NavRegionMinSize              "8"
+        NavRegionMergeSize            "20"
+        NavEdgeMaxLen                 "1200"
+        NavEdgeMaxError               "51.0"
+        NavVertsPerPoly               "4"
+        NavDetailSampleDistance       "120.0"
+        NavDetailSampleMaxError       "2.0"
+        NavSmallAreaOnEdgeRemovalSize "81.0"
     }
 
     AnimationSystem
     {
-        "DisableServerInterpCompensation"   "1"
-        "DisableAnimationScript"    "1"
-        "ServerPoseRecipeHistorySize"   "60"
-        "ClientPoseRecipeHistorySize"   "60"
+        DisableServerInterpCompensation "1"
+        DisableAnimationScript          "1"
+        ServerPoseRecipeHistorySize     "60"
+        ClientPoseRecipeHistorySize     "60"
 
     }
 
     ModelDoc
     {
-        "models_gamedata"           "models_gamedata.fgd"
-        "features"                  "animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
+        models_gamedata "models_gamedata.fgd"
+        features        "animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
     }
 
     Particles
     {
-        "EnableParticleShaderFeatureBranching"  "1"
-        "Float16HDRBackBuffer" "1"
-        "PET_SupportFadingOpaqueModels" "1"
-        "Features" "non_homogenous_forward_layer_only"
-        "ParticleTraceOffsetOnlyHit" "1"
-        "ParticlesFoggedByDefault" "0"
+        EnableParticleShaderFeatureBranching "1"
+        Float16HDRBackBuffer                 "1"
+        PET_SupportFadingOpaqueModels        "1"
+        Features                             "non_homogenous_forward_layer_only"
+        ParticleTraceOffsetOnlyHit           "1"
+        ParticlesFoggedByDefault             "0"
     }
 
     ConVars
     {
-//      If you would like to donate as a means of showing thanks I have a kofi.     \\
-//      https://ko-fi.com/sqooky                                                    \\
+        //      If you would like to donate as a means of showing thanks I have a kofi.     \\
+        //      https://ko-fi.com/sqooky                                                    \\
 
-// ---------------- GAMEINFO CONFIG OptimizationLock -- ver. 2 --------------- \\
-            // Check here for updates: https://gamebanana.com/mods/656341 \\
-           // Downloaded from: https://github.com/Sqooky/OptimizationLock  \\
-          // In-Depth Tutorial: https://www.youtube.com/watch?v=zC3wBYY98vU \\
+        // ---------------- GAMEINFO CONFIG OptimizationLock -- ver. 2 --------------- \\
+        // Check here for updates: https://gamebanana.com/mods/656341 \\
+        // Downloaded from: https://github.com/Sqooky/OptimizationLock  \\
+        // In-Depth Tutorial: https://www.youtube.com/watch?v=zC3wBYY98vU \\
 
 
-// Press ctrl+f and type * to highlight the more visually impactful commands that you could adjust
-// ================ Preferences ================
+        // Press ctrl+f and type * to highlight the more visually impactful commands that you could adjust
+        // ================ Preferences ================
 
-// --- 1. Outlines ---
-citadel_boss_glow_disabled                  "0"             // Disables boss and walker glow/highlight effect.                  [def: "0]
-citadel_player_glow_disabled                "0"             // Disables player glow/highlight effect when pinged.               [def: "0"]
-citadel_player_outline_enemies              "true"          // turn off enemy outline DOES NOT BREAK BACKSTABBER OR PING THRU WALL
-citadel_trooper_friendly_glow_disabled      "false"         // was false doesnt work btw
-citadel_trooper_glow_disabled               "0"             // 1 = Disable friendly/enemy minion glow.                          [def: "0"]
-citadel_trooper_outline_enabled             "true"          // turn off trooper outline
-cl_glow_brightness                          "0"             // default 1
-r_citadel_npr_force_solid_outline           "true"          // Causes odd visual bugs with dragons and neutrals when set to true    [def: "false"]
-r_citadel_npr_outlines                      "true"          // Enable outlines on enemy players.                                [def: "true"]
-r_citadel_npr_outlines_max_dist             "600"           // Limits outline distance to reduce unnecessary processing.        [def: "1000"]
-r_citadel_selection_outline2_alpha          "255"           // Outlines on enemy players and abilities on a scale of 0-1.       [def: "0.8"]
+        // --- 1. Outlines ---
+        citadel_boss_glow_disabled             "0"     // Disables boss and walker glow/highlight effect.                  [def: "0]
+        citadel_player_glow_disabled           "0"     // Disables player glow/highlight effect when pinged.               [def: "0"]
+        citadel_player_outline_enemies         "true"  // turn off enemy outline DOES NOT BREAK BACKSTABBER OR PING THRU WALL
+        citadel_trooper_friendly_glow_disabled "false" // was false doesnt work btw
+        citadel_trooper_glow_disabled          "0"     // 1 = Disable friendly/enemy minion glow.                          [def: "0"]
+        citadel_trooper_outline_enabled        "true"  // turn off trooper outline
+        cl_glow_brightness                     "0"     // default 1
+        r_citadel_npr_force_solid_outline      "true"  // Causes odd visual bugs with dragons and neutrals when set to true    [def: "false"]
+        r_citadel_npr_outlines                 "true"  // Enable outlines on enemy players.                                [def: "true"]
+        r_citadel_npr_outlines_max_dist        "600"   // Limits outline distance to reduce unnecessary processing.        [def: "1000"]
+        r_citadel_selection_outline2_alpha     "255"   // Outlines on enemy players and abilities on a scale of 0-1.       [def: "0.8"]
 
-// --- 2. Field of View ---
-citadel_camera_hero_fov                     "90"            // The field of view angle of the camera when following a hero.     [def: "90"]
-r_aspectratio                               "2.15"          // 1.75=80fov | 2.15=90fov | 2.49=100fov (every .15 interval = 5 fov). 
+        // --- 2. Field of View ---
+        citadel_camera_hero_fov "90"   // The field of view angle of the camera when following a hero.     [def: "90"]
+        r_aspectratio           "2.15" // 1.75=80fov | 2.15=90fov | 2.49=100fov (every .15 interval = 5 fov).
 
-// --- 3. HUD ---
-citadel_crosshair_hit_marker_duration       "0.01"          // Removes the hitmarker when shooting people.                      [def: "0.1"]
-citadel_damage_offscreen_indicator_disabled "1"             // The little trooper portraits that show up behind walls.          [def: "true"]
-citadel_damage_report_enable                "1"             // Enables/Disables incoming/outgoing damage tab (tuning this off is very questionable but okay). [def: "1"]
-citadel_damage_text_lifetime                "0.5"           
-citadel_damage_text_show_effectiveness      "0"             // Shows extra “effectiveness” info in damage text (e.g., resist/weakness style feedback). [def: "0"]
-citadel_hideout_ball_show_juggle_count      "1"             // Shows a fun juggle count minigame for hideout ball.              [def: "0"]
-citadel_hideout_ball_show_juggle_fx         "1"             // Shows juggle visual FX for hideout ball minigame.                [def: "0"]
-citadel_hud_objective_health_enabled        "2"             // 0=Off, 1=Shrines, 2=T1/T2, 3=Barracks.                           [def: "2"]
-citadel_hud_objective_health_idle_timeout   "4"             
-citadel_in_world_item_panel_dpi             "0.25"          
-citadel_minimap_use_canvas_for_neutrals     "0"             // Uses an alternate “canvas” rendering path for neutral icons on the minimap (render path toggle). [def: "1"]
-citadel_minimap_use_canvas_for_shop         "0"             // Uses an alternate “canvas” rendering path for shop icons on the minimap (render path toggle). [def: "1"]
-citadel_portrait_world_renderer_off         "true"          // Set true to disable hero hud
-citadel_show_new_damage_feedback_numbers    "0"             // Set 1 to enable
-citadel_unit_status_delta_decay_delay       "0"             
-citadel_unit_status_delta_decay_rate        "10"            
-citadel_unit_status_old_update_rate         "15"            // might fuck with health bars
-citadel_unit_status_use_new                 "0"             // This uses new Health Bar, to use old Health Bar change "true" to "false".    [def: "0"]
-r_citadel_glow_health_bars                  "false"         // default true
+        // --- 3. HUD ---
+        citadel_crosshair_hit_marker_duration       "0.01" // Removes the hitmarker when shooting people.                      [def: "0.1"]
+        citadel_damage_offscreen_indicator_disabled "1"    // The little trooper portraits that show up behind walls.          [def: "true"]
+        citadel_damage_report_enable                "1"    // Enables/Disables incoming/outgoing damage tab (tuning this off is very questionable but okay). [def: "1"]
+        citadel_damage_text_lifetime                "0.5"
+        citadel_damage_text_show_effectiveness      "0" // Shows extra “effectiveness” info in damage text (e.g., resist/weakness style feedback). [def: "0"]
+        citadel_hideout_ball_show_juggle_count      "1" // Shows a fun juggle count minigame for hideout ball.              [def: "0"]
+        citadel_hideout_ball_show_juggle_fx         "1" // Shows juggle visual FX for hideout ball minigame.                [def: "0"]
+        citadel_hud_objective_health_enabled        "2" // 0=Off, 1=Shrines, 2=T1/T2, 3=Barracks.                           [def: "2"]
+        citadel_hud_objective_health_idle_timeout   "4"
+        citadel_in_world_item_panel_dpi             "0.25"
+        citadel_minimap_use_canvas_for_neutrals     "0"    // Uses an alternate “canvas” rendering path for neutral icons on the minimap (render path toggle). [def: "1"]
+        citadel_minimap_use_canvas_for_shop         "0"    // Uses an alternate “canvas” rendering path for shop icons on the minimap (render path toggle). [def: "1"]
+        citadel_portrait_world_renderer_off         "true" // Set true to disable hero hud
+        citadel_show_new_damage_feedback_numbers    "0"    // Set 1 to enable
+        citadel_unit_status_delta_decay_delay       "0"
+        citadel_unit_status_delta_decay_rate        "10"
+        citadel_unit_status_old_update_rate         "15"    // might fuck with health bars
+        citadel_unit_status_use_new                 "0"     // This uses new Health Bar, to use old Health Bar change "true" to "false".    [def: "0"]
+        r_citadel_glow_health_bars                  "false" // default true
 
-// --- 4. Lighting & Shadows ---
-lb_enable_baked_shadows                     "0"             // *Disables baked shadows (game looks bright if this is on while stationary lights = 1). [def: "1"]
-lb_enable_dynamic_lights                    "0"             // *Disables dynamic lights eg. walker, shop, tp, character abilities etc. (hero silhouettes go dark in menus as a side effect) [def: "1"]
-lb_enable_lights                            "0"             // was 1
-lb_enable_stationary_lights                 "0"             // *Disables stationary lights (map looks flatter but more performant).         [def: "1"]
-lb_enable_sunlight                          "false"         // Default: true SceneSystem/LightBinner/Enable Sunlight
+        // --- 4. Lighting & Shadows ---
+        lb_enable_baked_shadows     "0"     // *Disables baked shadows (game looks bright if this is on while stationary lights = 1). [def: "1"]
+        lb_enable_dynamic_lights    "0"     // *Disables dynamic lights eg. walker, shop, tp, character abilities etc. (hero silhouettes go dark in menus as a side effect) [def: "1"]
+        lb_enable_lights            "0"     // was 1
+        lb_enable_stationary_lights "0"     // *Disables stationary lights (map looks flatter but more performant).         [def: "1"]
+        lb_enable_sunlight          "false" // Default: true SceneSystem/LightBinner/Enable Sunlight
 
-// --- 5. Skybox Rendering ---
-fog_enableskybox                            "0"             
-r_draw3dskybox                              "0"             // Enables drawing the 3D skybox layer (distant geometry).         [def: "1"]
-r_drawskybox                                "0"             // Can't be changed anymore                                             [def: "true"]
-r_monitor_3dskybox                          "0"             
+        // --- 5. Skybox Rendering ---
+        fog_enableskybox   "0"
+        r_draw3dskybox     "0" // Enables drawing the 3D skybox layer (distant geometry).         [def: "1"]
+        r_drawskybox       "0" // Can't be changed anymore                                             [def: "true"]
+        r_monitor_3dskybox "0"
 
-// --- 6. FPS Caps & Minimized Throttling ---
-engine_low_latency_sleep_after_client_tick  "1"             // Sleeps strategically after client tick to reduce latency/stutter (low-latency pacing). [def: "false"]
-engine_no_focus_sleep                       "0"             // Milliseconds the engine sleeps per frame when unfocused (0 = no sleep, not recommended for low-end PC). [def: "20"]
-fps_max                                     "0"             // Max FPS while in game, limit fps to your monitor refresh rate. [def: "400"]
-panorama_max_fps                            "15"            // Menu FPS.                                                        [def: "120"]
-panorama_max_overlay_fps                    "15"            // Fps In the settings/esc menu.                                    [def: "60"]
+        // --- 6. FPS Caps & Minimized Throttling ---
+        engine_low_latency_sleep_after_client_tick "1"  // Sleeps strategically after client tick to reduce latency/stutter (low-latency pacing). [def: "false"]
+        engine_no_focus_sleep                      "0"  // Milliseconds the engine sleeps per frame when unfocused (0 = no sleep, not recommended for low-end PC). [def: "20"]
+        fps_max                                    "0"  // Max FPS while in game, limit fps to your monitor refresh rate. [def: "400"]
+        panorama_max_fps                           "15" // Menu FPS.                                                        [def: "120"]
+        panorama_max_overlay_fps                   "15" // Fps In the settings/esc menu.                                    [def: "60"]
 
-// --- 7. Object Culling ---
-r_size_cull_threshold                       "1.6"           // *Culls small objects sooner based on screen size threshold (higher = more culling). [def: "0.8"]
+        // --- 7. Object Culling ---
+        r_size_cull_threshold "1.6" // *Culls small objects sooner based on screen size threshold (higher = more culling). [def: "0.8"]
 
-// --- 8. Camera Tweaks ---
-citadel_camera_soft_collision               "0"             
-citadel_camera_wobble_disable               "1"             
+        // --- 8. Camera Tweaks ---
+        citadel_camera_soft_collision "0"
+        citadel_camera_wobble_disable "1"
 
-// --- 9. Texture Quality ---
-mat_set_shader_quality                      "0"             // Force shader quality setting (valid values are 0 or 1).          [def: null]
-r_fallback_texture_lod_scale                "4"             
-r_texture_budget_dynamic                    "1"             // Dynamic texture budget adjustment
-r_texture_budget_threshold                  "0.7"           // Reduce texture memory pool size when this percentage of the budget is full. [def: "0.8"]
-r_texture_budget_update_period              "0.5"           // Time (in seconds) between updating texture memory budget.        [def: "0.1"]
-r_texture_lod_scale                         "4"             // default: 1
-r_texture_pool_reduce_rate                  "512"           
-r_texture_pool_size                         "256"           // either 256 or 512
-r_texture_stream_max_resolution             "128"           
-r_texture_stream_mip_bias                   "8"             // Worth adjusting, practically how good your textures will look.
-r_texture_stream_resolution_bias            "0.01"          
-r_texturefilteringquality                   "0"             // Texture filtering, has very low fps impact. 0: Bilinear, 1: Trilinear, 2: Aniso 2x, 3: Aniso 4x, 4: Aniso 8x, 5: Aniso 16x
+        // --- 9. Texture Quality ---
+        mat_set_shader_quality           "0" // Force shader quality setting (valid values are 0 or 1).          [def: null]
+        r_fallback_texture_lod_scale     "4"
+        r_texture_budget_dynamic         "1"   // Dynamic texture budget adjustment
+        r_texture_budget_threshold       "0.7" // Reduce texture memory pool size when this percentage of the budget is full. [def: "0.8"]
+        r_texture_budget_update_period   "0.5" // Time (in seconds) between updating texture memory budget.        [def: "0.1"]
+        r_texture_lod_scale              "4"   // default: 1
+        r_texture_pool_reduce_rate       "512"
+        r_texture_pool_size              "256" // either 256 or 512
+        r_texture_stream_max_resolution  "128"
+        r_texture_stream_mip_bias        "8" // Worth adjusting, practically how good your textures will look.
+        r_texture_stream_resolution_bias "0.01"
+        r_texturefilteringquality        "0" // Texture filtering, has very low fps impact. 0: Bilinear, 1: Trilinear, 2: Aniso 2x, 3: Aniso 4x, 4: Aniso 8x, 5: Aniso 16x
 
-// --- 10. Render Distance ---
-r_farz                                      "6000"          // This controls the far clipping plane, ie building/player popin   [def: "-1"]
-r_mapextents                                "4500"          // Far clipping plane, this will make buildings pop in and out      [def: "16384"] damn that's an oddly specific number
-sv_waterdist                                "0"             
+        // --- 10. Render Distance ---
+        r_farz       "6000" // This controls the far clipping plane, ie building/player popin   [def: "-1"]
+        r_mapextents "4500" // Far clipping plane, this will make buildings pop in and out      [def: "16384"] damn that's an oddly specific number
+        sv_waterdist "0"
 
-// ================ IMPORTANT ================ 
-// Particle systems larger than this in every dimension skip culling to save CPU.  They will be drawn anyway 
-// So particle culling is handled by the CPU in deadlock, if you have GPU overhead to spare, consider lowering this value. 
-r_particle_max_size_cull                    "1600"          // 0 = DO NOT remove large particles (to see ultimates!). [def: "1200"], try 1600 and 1200
+        // ================ IMPORTANT ================
+        // Particle systems larger than this in every dimension skip culling to save CPU.  They will be drawn anyway
+        // So particle culling is handled by the CPU in deadlock, if you have GPU overhead to spare, consider lowering this value.
+        r_particle_max_size_cull "1600" // 0 = DO NOT remove large particles (to see ultimates!). [def: "1200"], try 1600 and 1200
 
-// ================ UI ================
-closecaption                                "false"         // I assume this does what it says on the tin                       [def: "false"]
-hud_free_cursor                             "0"             // Reduces UI input delay in minimap/spectator modes (not sure if this is true)
-mm_idle_enabled                             "false"         
-mm_idle_show_warning_at_s                   "999"           // How many seconds to wait before showing the idle warning dialog
-panorama_allow_transitions                  "false"         // Turns off UI anim (shop,etc)                                     [def: "1"]
-panorama_async_compute_mipgen               "1"             
-panorama_disable_blur                       "1"             // Disables UI blur effects in the UI.                              [def: "0"]
-panorama_disable_box_shadow                 "1"             // Disables UI box shadows in the UI (less GPU/UI cost).            [def: "0"]
-panorama_temp_comp_layer_min_dimension      "128"           // Based on the name I'm implied to believe this is the minimum size for panorama compositing, ie blur, rounded corners, etc. [def: "512"]
-panorama_transition_time_factor             "2"             // faster transition for the stuff that doesnt use animation
-panorama_use_new_occlusion_invalidation     "1"             // SPOOKY TESTING CONVARS HAS IT SET TO ZERO
-//r_citadel_enable_pano_world_blur            "false"         // Default: true Enable world-blur style
-r_dashboard_render_quality                  "0"             // Sets dashboard/UI render quality (lower = cheaper UI rendering). [def: "1"]
+        // ================ UI ================
+        closecaption                            "false" // I assume this does what it says on the tin                       [def: "false"]
+        hud_free_cursor                         "0"     // Reduces UI input delay in minimap/spectator modes (not sure if this is true)
+        mm_idle_enabled                         "false"
+        mm_idle_show_warning_at_s               "999"   // How many seconds to wait before showing the idle warning dialog
+        panorama_allow_transitions              "false" // Turns off UI anim (shop,etc)                                     [def: "1"]
+        panorama_async_compute_mipgen           "1"
+        panorama_disable_blur                   "1"     // Disables UI blur effects in the UI.                              [def: "0"]
+        panorama_disable_box_shadow             "1"     // Disables UI box shadows in the UI (less GPU/UI cost).            [def: "0"]
+        panorama_temp_comp_layer_min_dimension  "128"   // Based on the name I'm implied to believe this is the minimum size for panorama compositing, ie blur, rounded corners, etc. [def: "512"]
+        panorama_transition_time_factor         "2"     // faster transition for the stuff that doesnt use animation
+        panorama_use_new_occlusion_invalidation "1"     // SPOOKY TESTING CONVARS HAS IT SET TO ZERO
+        // r_citadel_enable_pano_world_blur     "false" // Default: true Enable world-blur style
+        r_dashboard_render_quality              "0"     // Sets dashboard/UI render quality (lower = cheaper UI rendering). [def: "1"]
 
-// ================ Shadows ================
-cl_globallight_shadow_mode                  "0"             // No idea. It is disabled based on the name.                       [def: "2"]
-lb_barnlight_shadow_use_precomputed_vis     "0"             
-lb_barnlight_shadowmap_scale                "0.01"          // Scale for computed barnlight shadowmap size (lower = cheaper).   [def: "1"]
-lb_csm_cascade_size_override                "0.25"          // Enables overriding CSM cascade sizing rules (forces engine to use override values). [def: "1536"]
-lb_csm_cross_fade_override                  "0"             
-lb_csm_distance_fade_override               "0"             
-lb_csm_draw_alpha_tested                    "0"             // Prevents alpha-tested geometry from being included in CSM passes (cheaper, possible missing leaf/fence shadows). [def: "1"]
-lb_csm_draw_translucent                     "0"             // Prevents translucent objects from rendering into CSM (cheaper, fewer shadow details). [def: "1"]
-lb_csm_override_staticgeo_cascades          "0"             // Disables realistic static cascades/ shadows from being cast around dynamic shadows such as heroes, uses low quality baked shadows instead. [def: "1"]
-lb_csm_override_staticgeo_cascades_value    "0"             // Base range of static cascade affects around player shadows. (-1 = minimal/disabled override behavior). [def: "-1"]
-lb_csm_receiver_plane_depth_bias            "0.00002"       
-lb_csm_receiver_plane_depth_bias_transmissive_backface "0.0002" 
-lb_dynamic_shadow_penumbra                  "false"         // default true
-lb_dynamic_shadow_resolution                "false"         // default true
-lb_dynamic_shadow_resolution_base           "32"            // Base resolution for dynamic shadows (lower = cheaper).           [def: "1536"]
-lb_dynamic_shadow_resolution_quantization   "32"            // 64
-lb_enable_fog_mixed_shadows                 "0"             
-lb_enable_shadow_casting                    "0"             // Disables baked shadows I believe                                 [def: "1"]
-lb_mixed_shadows                            "false"         
-lb_precomputed_shadowmap_enable             "false"         
-lb_shadow_map_cull_empty_mixed              "true"          
-lb_ssss_samples                             "0"             // Subsurface sample count                                          [def: "11"]
-lb_sun_csm_size_cull_threshold_texels       "30"            // Culls tiny CSM contributions below a texel threshold (performance).              [def: "10"]
-r_citadel_distancefield_shadows             "false"         // Default: true
-r_citadel_gpu_culling_shadows               "true"          // Enables GPU-driven culling for shadow casters (performance).     [def: "0"]
-r_citadel_shadow_quality                    "0"             // Deadlock/Citadel shadow quality level (0 = lowest).              [def: "2"]
-r_citadel_shadowdb                          "256"           // Default: 2048
-r_shadows                                   "0"             // Disables dynamic shadows.                                        [def: "1"]
-r_size_cull_threshold_shadow                "200"           // Threshold of shadow map size percentage below which objects get culled (higher = cull more to save shadow cost). [def: "0.2"]
-sc_disable_shadow_materials                 "1"             
-sc_disable_spotlight_shadows                "1"             // Disables spotlight shadows.                                      [def: "0"]
-sc_instanced_mesh_lod_bias_shadow           "10"            // Bias for LOD selection of instanced meshes in shadowmaps
-sc_instanced_mesh_size_cull_bias_shadow     "10"            // Bias for size culling instanced meshes in shadowmaps
-sparseshadowtree_disable_for_viewmodel      "1"             // Disable SST generation and runtime for viewmodel (use original CSM rendering).   [def: "1"]
-sparseshadowtree_enable_rendering           "0"             // Enables Sparse Shadow Tree, rendering static geometry into shadow cascades.      [def: "0"]
-sparseshadowtree_parallel_generation        "2"             
-// lb_enable_envmaps                         "0"             // Gives fps but fucks up lighting
+        // ================ Shadows ================
+        cl_globallight_shadow_mode                             "0" // No idea. It is disabled based on the name.                       [def: "2"]
+        lb_barnlight_shadow_use_precomputed_vis                "0"
+        lb_barnlight_shadowmap_scale                           "0.01" // Scale for computed barnlight shadowmap size (lower = cheaper).   [def: "1"]
+        lb_csm_cascade_size_override                           "0.25" // Enables overriding CSM cascade sizing rules (forces engine to use override values). [def: "1536"]
+        lb_csm_cross_fade_override                             "0"
+        lb_csm_distance_fade_override                          "0"
+        lb_csm_draw_alpha_tested                               "0" // Prevents alpha-tested geometry from being included in CSM passes (cheaper, possible missing leaf/fence shadows). [def: "1"]
+        lb_csm_draw_translucent                                "0" // Prevents translucent objects from rendering into CSM (cheaper, fewer shadow details). [def: "1"]
+        lb_csm_override_staticgeo_cascades                     "0" // Disables realistic static cascades/ shadows from being cast around dynamic shadows such as heroes, uses low quality baked shadows instead. [def: "1"]
+        lb_csm_override_staticgeo_cascades_value               "0" // Base range of static cascade affects around player shadows. (-1 = minimal/disabled override behavior). [def: "-1"]
+        lb_csm_receiver_plane_depth_bias                       "0.00002"
+        lb_csm_receiver_plane_depth_bias_transmissive_backface "0.0002"
+        lb_dynamic_shadow_penumbra                             "false" // default true
+        lb_dynamic_shadow_resolution                           "false" // default true
+        lb_dynamic_shadow_resolution_base                      "32"    // Base resolution for dynamic shadows (lower = cheaper).           [def: "1536"]
+        lb_dynamic_shadow_resolution_quantization              "32"    // 64
+        lb_enable_fog_mixed_shadows                            "0"
+        lb_enable_shadow_casting                               "0" // Disables baked shadows I believe                                 [def: "1"]
+        lb_mixed_shadows                                       "false"
+        lb_precomputed_shadowmap_enable                        "false"
+        lb_shadow_map_cull_empty_mixed                         "true"
+        lb_ssss_samples                                        "0"     // Subsurface sample count                                          [def: "11"]
+        lb_sun_csm_size_cull_threshold_texels                  "30"    // Culls tiny CSM contributions below a texel threshold (performance).              [def: "10"]
+        r_citadel_distancefield_shadows                        "false" // Default: true
+        r_citadel_gpu_culling_shadows                          "true"  // Enables GPU-driven culling for shadow casters (performance).     [def: "0"]
+        r_citadel_shadow_quality                               "0"     // Deadlock/Citadel shadow quality level (0 = lowest).              [def: "2"]
+        r_citadel_shadowdb                                     "256"   // Default: 2048
+        r_shadows                                              "0"     // Disables dynamic shadows.                                        [def: "1"]
+        r_size_cull_threshold_shadow                           "200"   // Threshold of shadow map size percentage below which objects get culled (higher = cull more to save shadow cost). [def: "0.2"]
+        sc_disable_shadow_materials                            "1"
+        sc_disable_spotlight_shadows                           "1"  // Disables spotlight shadows.                                      [def: "0"]
+        sc_instanced_mesh_lod_bias_shadow                      "10" // Bias for LOD selection of instanced meshes in shadowmaps
+        sc_instanced_mesh_size_cull_bias_shadow                "10" // Bias for size culling instanced meshes in shadowmaps
+        sparseshadowtree_disable_for_viewmodel                 "1"  // Disable SST generation and runtime for viewmodel (use original CSM rendering).   [def: "1"]
+        sparseshadowtree_enable_rendering                      "0"  // Enables Sparse Shadow Tree, rendering static geometry into shadow cascades.      [def: "0"]
+        sparseshadowtree_parallel_generation                   "2"
+        // lb_enable_envmaps                                   "0" // Gives fps but fucks up lighting
 
-// ================ Lighting ================
-cl_retire_low_priority_lights               "1"             // Replaces/drops low-priority dynamic lights when higher-priority lights are present (helps cap dlight clutter/cost). [def: "0"]
-lb_cubemap_normalization_max                "1"             // Default: 32
-lb_cubemap_normalization_roughness_begin    "0.01"          // Default: 0.1
-lb_max_visible_barn_lights_override         "1"             
-lb_max_visible_envmaps_override             "4"             // default 4 DO NOT CHANGE OR IT BREAKS GAME
-mat_async_shader_load                       "1"             // I have no reason to believe the name doesn't match the function  [def: "0"]
-mat_max_lighting_complexity                 "1"             // default 8
-mat_tonemap_bloom_scale                     "0"             
-r_arealights                                "false"         // was true
-r_citadel_disable_npr_lighting              "false"         // default: false - might change to true
-r_citadel_distancefield_farfield_enable     "0"             // Disables long-range distance field effects.                      [def: "1"]
-r_citadel_ssao_bent_normals                 "false"         
-r_citadel_ssao_denoise_passes               "0"             
-r_citadel_ssao_quality                      "0"             // SSAO quality level (0 = lowest/off-ish).                         [def: "3"]
-r_citadel_ssao_radius                       "0"             
-r_citadel_ssao_thin_occluder_compensation   "0"             // Disables special handling for thin occluders in SSAO (cheaper).  [def: "0.5"]
-r_citadel_sun_shadow_slope_scale_depth_bias "1.0"           // \\                                                               [def: "3.54"]
-r_directlighting                            "true"          // Set to true to have your characters not be black in the shop     [def:"true"]
-r_directional_lightmaps                     "false"         // default true
-r_distancefield_enable                      "0"             // Disables/ Enables distance-field system (used by some lighting/shadowing/occlusion features). [def: "1"]
-r_environment_map_roughness_range           "0.01"          // Default: 0.2 0.3 Fade region for sampling environment maps on lightmapped nonmetals... BASICALLY TURN OFF REFLECTIONS ON MAP I THINK
-r_flashlightbrightness                      "0"             
-r_flashlightfar                             "0"             
-r_flashlightshadowatten                     "0"             
-r_gbuffer_disable_npr_lighting              "true"          // might change to true
-r_light_flickering_enabled                  "false"         // Enables light flicker effects where used.                        [def: "1"]
-r_light_sensitivity_mode                    "true"          
-r_lightmap_bicubic_filtering                "1"             // Enables bicubic filtering on lightmaps.                          [def: "1"]
-r_lightmap_size                             "4"             // Maximum lightmap resolution..                                    [def: "65536"]
-r_lightmap_size_directional_irradiance      "0"             // Sets directional irradiance lightmap data size (lower = less detail) (-1 = uses value of r_lightmap_size ). [def: "-1"]
-r_multiscattering                           "1"             // Enables multi-scattering lighting approximation.                 [def: "1"]
-r_rendersun                                 "false"         // Disables sun lighting.                                           [def: "1"]
-r_ssao                                      "0"             // Disables screen-space ambient occlusion.                         [def: "1"]
-r_ssao_blur                                 "0"             
-r_ssao_strength                             "0"             // AO strength multiplier (0 = no AO contribution).                 [def: "1.2"]
-sc_cache_envmap_lpv_lookup                  "false"         // was true
-thumper_use_plane_reflection                "false"         // Default: true
-vis_sunlight_enable                         "0"             
+        // ================ Lighting ================
+        cl_retire_low_priority_lights               "1"    // Replaces/drops low-priority dynamic lights when higher-priority lights are present (helps cap dlight clutter/cost). [def: "0"]
+        lb_cubemap_normalization_max                "1"    // Default: 32
+        lb_cubemap_normalization_roughness_begin    "0.01" // Default: 0.1
+        lb_max_visible_barn_lights_override         "1"
+        lb_max_visible_envmaps_override             "4" // default 4 DO NOT CHANGE OR IT BREAKS GAME
+        mat_async_shader_load                       "1" // I have no reason to believe the name doesn't match the function  [def: "0"]
+        mat_max_lighting_complexity                 "1" // default 8
+        mat_tonemap_bloom_scale                     "0"
+        r_arealights                                "false" // was true
+        r_citadel_disable_npr_lighting              "false" // default: false - might change to true
+        r_citadel_distancefield_farfield_enable     "0"     // Disables long-range distance field effects.                      [def: "1"]
+        r_citadel_ssao_bent_normals                 "false"
+        r_citadel_ssao_denoise_passes               "0"
+        r_citadel_ssao_quality                      "0" // SSAO quality level (0 = lowest/off-ish).                         [def: "3"]
+        r_citadel_ssao_radius                       "0"
+        r_citadel_ssao_thin_occluder_compensation   "0"     // Disables special handling for thin occluders in SSAO (cheaper).  [def: "0.5"]
+        r_citadel_sun_shadow_slope_scale_depth_bias "1.0"   // \\                                                               [def: "3.54"]
+        r_directlighting                            "true"  // Set to true to have your characters not be black in the shop     [def:"true"]
+        r_directional_lightmaps                     "false" // default true
+        r_distancefield_enable                      "0"     // Disables/ Enables distance-field system (used by some lighting/shadowing/occlusion features). [def: "1"]
+        r_environment_map_roughness_range           "0.01"  // Default: 0.2 0.3 Fade region for sampling environment maps on lightmapped nonmetals... BASICALLY TURN OFF REFLECTIONS ON MAP I THINK
+        r_flashlightbrightness                      "0"
+        r_flashlightfar                             "0"
+        r_flashlightshadowatten                     "0"
+        r_gbuffer_disable_npr_lighting              "true"  // might change to true
+        r_light_flickering_enabled                  "false" // Enables light flicker effects where used.                        [def: "1"]
+        r_light_sensitivity_mode                    "true"
+        r_lightmap_bicubic_filtering                "1"     // Enables bicubic filtering on lightmaps.                          [def: "1"]
+        r_lightmap_size                             "4"     // Maximum lightmap resolution..                                    [def: "65536"]
+        r_lightmap_size_directional_irradiance      "0"     // Sets directional irradiance lightmap data size (lower = less detail) (-1 = uses value of r_lightmap_size ). [def: "-1"]
+        r_multiscattering                           "1"     // Enables multi-scattering lighting approximation.                 [def: "1"]
+        r_rendersun                                 "false" // Disables sun lighting.                                           [def: "1"]
+        r_ssao                                      "0"     // Disables screen-space ambient occlusion.                         [def: "1"]
+        r_ssao_blur                                 "0"
+        r_ssao_strength                             "0"     // AO strength multiplier (0 = no AO contribution).                 [def: "1.2"]
+        sc_cache_envmap_lpv_lookup                  "false" // was true
+        thumper_use_plane_reflection                "false" // Default: true
+        vis_sunlight_enable                         "0"
 
-// ================ Ragdolls ================
-ai_use_async_ragdoll_fixup                  "true"          // doesnt really need tbh since ragdoll is disabled
-cl_disable_ragdolls                         "1"             // Keep set to 0 - enabling this (disabling ragdolls) can cause issue with doorman's ultimate. [def: "0"]
-cl_ragdoll_default_scale                    "0"             // default 1 doesnt matter since ragdoll disabled
-cl_ragdoll_limit                            "0"             // Limit of how many ragdolls can be rendered at once.              [def: "-1"]
-g_ragdoll_important_maxcount                "1"             
-ragdoll_parallel_pose_control               "1"             // Multithreaded ragdoll handling, better performance (if ragdolls aren't disabled). [def: "0"]
+        // ================ Ragdolls ================
+        ai_use_async_ragdoll_fixup    "true" // doesnt really need tbh since ragdoll is disabled
+        cl_disable_ragdolls           "1"    // Keep set to 0 - enabling this (disabling ragdolls) can cause issue with doorman's ultimate. [def: "0"]
+        cl_ragdoll_default_scale      "0"    // default 1 doesnt matter since ragdoll disabled
+        cl_ragdoll_limit              "0"    // Limit of how many ragdolls can be rendered at once.              [def: "-1"]
+        g_ragdoll_important_maxcount  "1"
+        ragdoll_parallel_pose_control "1" // Multithreaded ragdoll handling, better performance (if ragdolls aren't disabled). [def: "0"]
 
-// ================ Models ================
-// skeleton_instance_lod_optimization        "1"             // Enables skeleton/animation LOD optimizations (less bone work for distant models). [def: "0"]
-anim_decode_forcewritealltransforms         "true"          // Default: false Force BatchAnimationDecode to write transformations for all bones
-anim_disable                                "true"          
-animgraph_enable_parallel_op_evaluation     "1"             // Allows animgraph operator evaluation to run in parallel (performance).   [def: "0"]
-animgraph_enable_parallel_preupdate         "1"             // Allows animgraph pre-update work to run in parallel (performance).       [def: "0"]
-animgraph_footlock_enabled                  "false"         
-animgraph_slowdownonslopes_enabled          "false"         
-cl_bone_cache_optimization                  "1"             
-cl_fasttempentcollision                     "999999"        // Limits/controls fast collision processing for temporary entities (impacts/tracers/etc.); higher usually = more work. [def: "5"]
-cloth_sim_on_tick                           "0"             // Update the cloth simulation every tick                           [def: "1"]
-cloth_update                                "1"             // Enables cloth system updates. [def: "1"]
-enable_boneflex                             "false"         // Disables bone flexes (procedural facial/mesh flex drivers).      [def: "1"]
-func_break_max_pieces                       "1"             // lets try 0 and 1
-ik_fabrik_align_chain                       "0"             // Disables FABRIK chain alignment in IK (cheaper).                 [def: "1"]
-ik_final_fixup_enable                       "0"             // Disables final IK fixup pass (cheaper animations, potentially less accurate). [def: "1"]
-mesh_calculate_curvature_smooth_pass_count  "0"             
-phys_threaded_cloth_bone_update             "1"             // I am inclined to believe this makes the cloth update threaded    [def: "0"]
-phys_threaded_kinematic_bone_update         "1"             // I am inclined to believe this makes the cloth kinematics threaded    [def: "0"]
-phys_threaded_transform_update              "1"             // Same as above                                                    [def: "0"]
-pred_cloth_pos_max                          "0"             // Reduce cloth prediction was 1
-pred_cloth_pos_multiplier                   "0"             // was 0.3
-pred_cloth_pos_strength                     "0"             // was 0.1
-pred_cloth_rot_high                         "0"             // was 0.05
-pred_cloth_rot_low                          "0"             // was 0.005
-pred_cloth_rot_multiplier                   "0"             // was 0.2 changing these values does fucking nothing
-presettle_cloth_iterations                  "0"             // default 3
-props_break_apply_radial_forces             "0"             // default: 1
-props_break_max_pieces_perframe             "0.5"           // Makes boxes and troopers break into a single piece               [def: "16"]
-r_hair_ao                                   "0"             // Disables hair ambient occlusion/shading pass.                    [def: "1"]
-r_hair_indirect_transmittance               "false"         
-r_hair_shadowtile                           "false"         
-r_haircull_percent                          "100"           
-r_morphing_enabled                          "false"         
-r_render_hair                               "0"             
-r_smooth_morph_normals                      "0"             
+        // ================ Models ================
+        // skeleton_instance_lod_optimization      "1"    // Enables skeleton/animation LOD optimizations (less bone work for distant models). [def: "0"]
+        anim_decode_forcewritealltransforms        "true" // Default: false Force BatchAnimationDecode to write transformations for all bones
+        anim_disable                               "true"
+        animgraph_enable_parallel_op_evaluation    "1" // Allows animgraph operator evaluation to run in parallel (performance).   [def: "0"]
+        animgraph_enable_parallel_preupdate        "1" // Allows animgraph pre-update work to run in parallel (performance).       [def: "0"]
+        animgraph_footlock_enabled                 "false"
+        animgraph_slowdownonslopes_enabled         "false"
+        cl_bone_cache_optimization                 "1"
+        cl_fasttempentcollision                    "999999" // Limits/controls fast collision processing for temporary entities (impacts/tracers/etc.); higher usually = more work. [def: "5"]
+        cloth_sim_on_tick                          "0"      // Update the cloth simulation every tick                           [def: "1"]
+        cloth_update                               "1"      // Enables cloth system updates. [def: "1"]
+        enable_boneflex                            "false"  // Disables bone flexes (procedural facial/mesh flex drivers).      [def: "1"]
+        func_break_max_pieces                      "1"      // lets try 0 and 1
+        ik_fabrik_align_chain                      "0"      // Disables FABRIK chain alignment in IK (cheaper).                 [def: "1"]
+        ik_final_fixup_enable                      "0"      // Disables final IK fixup pass (cheaper animations, potentially less accurate). [def: "1"]
+        mesh_calculate_curvature_smooth_pass_count "0"
+        phys_threaded_cloth_bone_update            "1"   // I am inclined to believe this makes the cloth update threaded    [def: "0"]
+        phys_threaded_kinematic_bone_update        "1"   // I am inclined to believe this makes the cloth kinematics threaded    [def: "0"]
+        phys_threaded_transform_update             "1"   // Same as above                                                    [def: "0"]
+        pred_cloth_pos_max                         "0"   // Reduce cloth prediction was 1
+        pred_cloth_pos_multiplier                  "0"   // was 0.3
+        pred_cloth_pos_strength                    "0"   // was 0.1
+        pred_cloth_rot_high                        "0"   // was 0.05
+        pred_cloth_rot_low                         "0"   // was 0.005
+        pred_cloth_rot_multiplier                  "0"   // was 0.2 changing these values does fucking nothing
+        presettle_cloth_iterations                 "0"   // default 3
+        props_break_apply_radial_forces            "0"   // default: 1
+        props_break_max_pieces_perframe            "0.5" // Makes boxes and troopers break into a single piece               [def: "16"]
+        r_hair_ao                                  "0"   // Disables hair ambient occlusion/shading pass.                    [def: "1"]
+        r_hair_indirect_transmittance              "false"
+        r_hair_shadowtile                          "false"
+        r_haircull_percent                         "100"
+        r_morphing_enabled                         "false"
+        r_render_hair                              "0"
+        r_smooth_morph_normals                     "0"
 
-// ================ Visual Clarity ================
-// r_dopixelvisibility                       "false"         // Default true, enables or disables pixel visibility calculations
-// r_draw_overlays                           "false"         // Removes the walker line on the ground too, do not recommend
-citadel_per_weapon_per_surface_impact_effects "false"       
-cl_impacteffects                            "0"             
-cl_show_splashes                            "0"             // Disables splash effects (water/impact splashes).                 [def: "1"]
-fog_enable                                  "0"             
-fx_drawmetalspark                           "false"         // Default: true Draw metal spark effects.
-mat_colcorrection_disableentities           "0"             // Allows entity-based color correction. [def: "0"]
-mat_colorcorrection                         "1"             // Disables/ Enables color correction (game looks less vibrant when off).   [def: "1"]
-r_character_decal_monitor_render_res        "64"            // default: 512
-r_character_decal_resolution                "0.01"          // Resolution of character decal texture.                           [def: "1024"]
-r_citadel_antialiasing                      "0"             // default 1
-r_citadel_depthoffield_enable               "false"         
-r_citadel_distancefield_blur                "false"         // default: true
-r_citadel_fog_quality                       "0"             // Deadlock/Citadel fog quality (0 = lowest). [def: "1"]
-r_decals                                    "1"             // Maximum number of decals allowed. (lower = fewer bullet holes/blood/impact marks). [def: "2048"]
-r_decals_default_fade_duration              "0.001"         // How quickly decals (bullet holes) fade                           [def: "3"]
-r_decals_default_start_fade                 "0.001"         
-r_decals_max_on_deformables                 "0"             
-r_decals_overlap_threshold                  "5"             
-r_depth_of_field                            "0"             // Disables depth of field.                                         [def: "1"]
-r_drawdecals                                "0"             // *Render decals.                                                  [def: "1"]
-r_drawmodeldecals                           "0"             // does not exist in master convar
-r_drawtracers                               "0"             
-r_drawtracers_firstperson                   "0"             
-r_effects_bloom                             "0"             // Disables effects bloom.                                          [def: "1"]
-r_enable_cubemap_fog                        "0"             // Disables cubemap-based fog. [def: "1"]
-r_enable_gradient_fog                       "0"             // Disables gradient fog. [def: "1"]
-r_enable_volume_fog                         "0"             // Disables volumetric fog. [def: "1"]
-r_fullscreen_gamma                          "2.2"           // recommended ppl to use this to make the game brighter, bigge number = darker
-r_muzzleflashbrightness                     "0.01"          // default 0.4 idk if this does anything
-r_post_bloom                                "0"             // Disables post-process bloom.                                     [def: "1"]
-r_postprocess_enable                        "true"          // default true
-sc_clutter_enable                           "0"             // Disables clutter props, improves visibility & FPS.               [def: "true"]
-violence_ablood                             "false"         // Disables alien/other blood effects.                              [def: "1"]
-violence_agibs                              "false"         // Disables alien/other gibs.                                       [def: "1"]
-violence_hblood                             "false"         // Disables human blood effects.                                    [def: "1"]
-violence_hgibs                              "false"         // Disables human gibs.                                             [def: "1"]
-volume_fog_intermediate_textures_hdr        "0"             // See below                                                        [def: "true"]
+        // ================ Visual Clarity ================
+        // r_dopixelvisibility                        "false" // Default true, enables or disables pixel visibility calculations
+        // r_draw_overlays                            "false" // Removes the walker line on the ground too, do not recommend
+        citadel_per_weapon_per_surface_impact_effects "false"
+        cl_impacteffects                              "0"
+        cl_show_splashes                              "0" // Disables splash effects (water/impact splashes).                 [def: "1"]
+        fog_enable                                    "0"
+        fx_drawmetalspark                             "false" // Default: true Draw metal spark effects.
+        mat_colcorrection_disableentities             "0"     // Allows entity-based color correction. [def: "0"]
+        mat_colorcorrection                           "1"     // Disables/ Enables color correction (game looks less vibrant when off).   [def: "1"]
+        r_character_decal_monitor_render_res          "64"    // default: 512
+        r_character_decal_resolution                  "0.01"  // Resolution of character decal texture.                           [def: "1024"]
+        r_citadel_antialiasing                        "0"     // default 1
+        r_citadel_depthoffield_enable                 "false"
+        r_citadel_distancefield_blur                  "false" // default: true
+        r_citadel_fog_quality                         "0"     // Deadlock/Citadel fog quality (0 = lowest). [def: "1"]
+        r_decals                                      "1"     // Maximum number of decals allowed. (lower = fewer bullet holes/blood/impact marks). [def: "2048"]
+        r_decals_default_fade_duration                "0.001" // How quickly decals (bullet holes) fade                           [def: "3"]
+        r_decals_default_start_fade                   "0.001"
+        r_decals_max_on_deformables                   "0"
+        r_decals_overlap_threshold                    "5"
+        r_depth_of_field                              "0" // Disables depth of field.                                         [def: "1"]
+        r_drawdecals                                  "0" // *Render decals.                                                  [def: "1"]
+        r_drawmodeldecals                             "0" // does not exist in master convar
+        r_drawtracers                                 "0"
+        r_drawtracers_firstperson                     "0"
+        r_effects_bloom                               "0"     // Disables effects bloom.                                          [def: "1"]
+        r_enable_cubemap_fog                          "0"     // Disables cubemap-based fog. [def: "1"]
+        r_enable_gradient_fog                         "0"     // Disables gradient fog. [def: "1"]
+        r_enable_volume_fog                           "0"     // Disables volumetric fog. [def: "1"]
+        r_fullscreen_gamma                            "2.2"   // recommended ppl to use this to make the game brighter, bigge number = darker
+        r_muzzleflashbrightness                       "0.01"  // default 0.4 idk if this does anything
+        r_post_bloom                                  "0"     // Disables post-process bloom.                                     [def: "1"]
+        r_postprocess_enable                          "true"  // default true
+        sc_clutter_enable                             "0"     // Disables clutter props, improves visibility & FPS.               [def: "true"]
+        violence_ablood                               "false" // Disables alien/other blood effects.                              [def: "1"]
+        violence_agibs                                "false" // Disables alien/other gibs.                                       [def: "1"]
+        violence_hblood                               "false" // Disables human blood effects.                                    [def: "1"]
+        violence_hgibs                                "false" // Disables human gibs.                                             [def: "1"]
+        volume_fog_intermediate_textures_hdr          "0"     // See below                                                        [def: "true"]
 
-// ================ Network ================
-// cl_clock_buffer_ticks                     "0"             // Testing set 1 to smooth over packet loss
-// cl_interp                                 "0.01"          // Client-side interpolation time (smoothing delay) for rendering other players/entities. [def: "0"]
-// cl_interp_ratio                           "1"             // Multiplier that affects interpolation time (often cl_interp_ratio / cl_updaterate). [def: "0"]
-// cl_predict_after_every_createmove         "0"             // Test 1 0
-// cl_predictioncopy_runs                    "0"             // Put to 1 if character vibrates
-// net_skip_redundant_change_callbacks       "true"          // Default false, im p sure this keep pulling up report screen for some reason
-cl_async_usercmd_send                       "true"          // Makes the client send updates asyncronously I belive. Seems to smooth over network jank, although you will need to remove it from lower down in the gameinfo.gi [def: "false"]
-cl_eye_yaw_multiplier                       "0"             
-cl_parallel_readpacketentities              "1"             
-cl_parallel_readpacketentities_threshold    "2"             
-cl_prediction_savedata_postentitypacketreceived "1"         
-cl_resend                                   "15"            // Delay in seconds between reconnect attempts (higher = less frequent, helps avoid kicks/timeouts on unstable connections). [def: "0.5"]
-cl_smooth_draw_debug                        "0"             
-cl_smoothtime                               "0.01"          // Smooth client's view after prediction error over this many seconds (Lower = snappier but more abrupt, higher = smoother but floaty). [def: "0.2"]
-cl_updaterate                               "128"           // Client snapshot update rate requested from the server (higher = more frequent updates).      [def: "128"]
-net_async_clientconnect                     "1"             
-r_frame_sync_enable                         "0"             // was 0
-sv_parallel_sendsnapshot                    "2"             
+        // ================ Network ================
+        // cl_clock_buffer_ticks                        "0"    // Testing set 1 to smooth over packet loss
+        // cl_interp                                    "0.01" // Client-side interpolation time (smoothing delay) for rendering other players/entities. [def: "0"]
+        // cl_interp_ratio                              "1"    // Multiplier that affects interpolation time (often cl_interp_ratio / cl_updaterate). [def: "0"]
+        // cl_predict_after_every_createmove            "0"    // Test 1 0
+        // cl_predictioncopy_runs                       "0"    // Put to 1 if character vibrates
+        // net_skip_redundant_change_callbacks          "true" // Default false, im p sure this keep pulling up report screen for some reason
+        cl_async_usercmd_send                           "true" // Makes the client send updates asyncronously I belive. Seems to smooth over network jank, although you will need to remove it from lower down in the gameinfo.gi [def: "false"]
+        cl_eye_yaw_multiplier                           "0"
+        cl_parallel_readpacketentities                  "1"
+        cl_parallel_readpacketentities_threshold        "2"
+        cl_prediction_savedata_postentitypacketreceived "1"
+        cl_resend                                       "15" // Delay in seconds between reconnect attempts (higher = less frequent, helps avoid kicks/timeouts on unstable connections). [def: "0.5"]
+        cl_smooth_draw_debug                            "0"
+        cl_smoothtime                                   "0.01" // Smooth client's view after prediction error over this many seconds (Lower = snappier but more abrupt, higher = smoother but floaty). [def: "0.2"]
+        cl_updaterate                                   "128"  // Client snapshot update rate requested from the server (higher = more frequent updates).      [def: "128"]
+        net_async_clientconnect                         "1"
+        r_frame_sync_enable                             "0" // was 0
+        sv_parallel_sendsnapshot                        "2"
 
-// ================ System Related ================
-// engine_allow_multiple_simulates_per_frame "false"         // Default false, not sure about this one so dont change it
-// engine_allow_multiple_ticks_per_frame     "0"             // Remove
-// fs_async_threads                          "8"             
-// mat_disable_dynamic_shader_compile        "1"             // BUGGY
-battery_saver                               "0"             // Disables battery saver mode (no automatic throttling).                   [def: "0"]
-cpu_level                                   "1"             // CPU level.                                                               [def: "2"]
-enable_priority_boost                       "1"             
-engine_max_ticks_to_simulate                "33"            // Max number of ticks to simulate per frame, after which simulation will start to slow down compared to real time. [Def: "-1"]
-gpu_level                                   "1"             // GPU level literally doesn't matter, gets set to 2 in the engine
-gpu_mem_level                               "1"             // GPU Memory level.                                                        [def: "2"]
-r_low_latency                               "1"             // This acts as the convar which enables low latency, hardware dependent    [def: "1"]
-think_limit                                 "10"            // Limits how much “think” time/entities can process per tick (CPU cap).    [def: "10"]
+        // ================ System Related ================
+        // engine_allow_multiple_simulates_per_frame "false" // Default false, not sure about this one so dont change it
+        // engine_allow_multiple_ticks_per_frame     "0"     // Remove
+        // fs_async_threads                          "8"
+        // mat_disable_dynamic_shader_compile        "1" // BUGGY
+        battery_saver                                "0" // Disables battery saver mode (no automatic throttling).                   [def: "0"]
+        cpu_level                                    "1" // CPU level.                                                               [def: "2"]
+        enable_priority_boost                        "1"
+        engine_max_ticks_to_simulate                 "33" // Max number of ticks to simulate per frame, after which simulation will start to slow down compared to real time. [Def: "-1"]
+        gpu_level                                    "1"  // GPU level literally doesn't matter, gets set to 2 in the engine
+        gpu_mem_level                                "1"  // GPU Memory level.                                                        [def: "2"]
+        r_low_latency                                "1"  // This acts as the convar which enables low latency, hardware dependent    [def: "1"]
+        think_limit                                  "10" // Limits how much “think” time/entities can process per tick (CPU cap).    [def: "10"]
 
-// ================ Input ================
-cl_input_enable_raw_keyboard                "1"             // Enables raw keyboard input handling (more direct input path).[def: "0"]
-m_rawinput                                  "1"             
+        // ================ Input ================
+        cl_input_enable_raw_keyboard "1" // Enables raw keyboard input handling (more direct input path).[def: "0"]
+        m_rawinput                   "1"
 
-// ================ Particles ================
-// cl_particle_sim_fallback_base_multiplier  "5"             // How aggressive the switch to fallbacks will be depending on how far over the cl_particle_sim_fallback_threshold_ms the sim time is. [def: "5"]
-cl_aggregate_particles                      "1"             
-cl_particle_batch_mode                      "1"             // Has a range of 1 or 2, 2 will make celeste's auto rebound look weird and 0 will make them not batch [def: "1"]
-cl_particle_fallback_base                   "10"            // Base for falling back to cheaper effects under load.             [def: "0"] 
-cl_particle_fallback_multiplier             "10"            // Multiplier for falling back to cheaper effects under load.       [def: "0"]
-cl_particle_max_count                       "0"             // Maximum allowed particles. Setting it too low will cause issues. With flooding from the console.  [def: "0"]
-cl_particle_sim_fallback_base_multiplier    "100"           // How aggressive the switch to fallbacks will be depending on how far over the cl_particle_sim_fallback_threshold_ms the sim time is.  Higher numbers are more aggressive. [def: "5"] 
-cl_particle_sim_fallback_threshold_ms       "0"             // Amount of simulation time that can elapse before new systems start falling back to cheaper versions [def: "6"] 
-particle_cluster_nodraw                     "1"             // Skips drawing particle “clusters”/grouped particle batches (performance, fewer small effects). [def: "0"]
-particle_cluster_use_collision_hulls        "false"         // REPLICATED CONVAR, MIGHT NEED TO MATCH WITH SERVER
-r_RainParticleDensity                       "0"             // Density of Particle Rain 0-1.                                    [def: "1"]
-r_citadel_screenspace_particles_full_res    "0"             
-r_draw_particle_children_with_parents       "0"             // I believe this handles the drawing of little visual flourish particles. [def: "-1"]
-r_drawparticles                             "true"          // default: true - might change to false again
-r_limit_particle_job_duration               "1"             // Seems to help with particle clutter, although I am not sure.             [def: "false"]
-r_particle_batch_collections                "true"          // Batches collections of particles, typically batch rendering is faster so this is set to true. [def: "false"]
-r_particle_cables_cast_shadows              "0"             // Disables shadow casting from cable/rope-like particle effects. [def: "1"]
-r_particle_cables_render                    "false"         // default true break lash ult, might need to set back to 1
-r_particle_cables_render_meshlets           "0"             
-r_particle_max_detail_level                 "0"             // The maximum detail level of particle to create.                  [def: "3"]
-r_particle_max_draw_distance                "300000"        // Lower = less particle range, more FPS, dont go below this value it doesnt draw trooper hp bar,
-r_particle_max_texture_layers               "4"             // Anything below 4 will make infernus afterburn, paige fire, and drifter's passive look very weird and blocky [def: "-1"]
-r_particle_min_timestep                     "0.001"         
-r_particle_mixed_resolution_viewstart       "800"           
-r_particle_model_new8                       "0"             // Disables newer particle models. [def: "1"]
-r_particle_model_per_thread_count           "32"            // I believe it is how many particle models a thread is allowed to handle.  [def: "32"]
-r_particle_skip_postsim                     "1"             // Not entirely sure what it does, going off of the name I'd imagine it skips the post simulation, this is a testvar [def: "false"]
-r_physics_particle_op_spawn_scale           "0"             // Prevents physics-based particle spawns.                          [def: "1"]
-r_world_wind_strength                       "0"             // Disables wind effects, cosmetic only.                            [def: "40"]
+        // ================ Particles ================
+        // cl_particle_sim_fallback_base_multiplier "5" // How aggressive the switch to fallbacks will be depending on how far over the cl_particle_sim_fallback_threshold_ms the sim time is. [def: "5"]
+        cl_aggregate_particles                      "1"
+        cl_particle_batch_mode                      "1"     // Has a range of 1 or 2, 2 will make celeste's auto rebound look weird and 0 will make them not batch [def: "1"]
+        cl_particle_fallback_base                   "10"    // Base for falling back to cheaper effects under load.             [def: "0"]
+        cl_particle_fallback_multiplier             "10"    // Multiplier for falling back to cheaper effects under load.       [def: "0"]
+        cl_particle_max_count                       "0"     // Maximum allowed particles. Setting it too low will cause issues. With flooding from the console.  [def: "0"]
+        cl_particle_sim_fallback_base_multiplier    "100"   // How aggressive the switch to fallbacks will be depending on how far over the cl_particle_sim_fallback_threshold_ms the sim time is.  Higher numbers are more aggressive. [def: "5"]
+        cl_particle_sim_fallback_threshold_ms       "0"     // Amount of simulation time that can elapse before new systems start falling back to cheaper versions [def: "6"]
+        particle_cluster_nodraw                     "1"     // Skips drawing particle “clusters”/grouped particle batches (performance, fewer small effects). [def: "0"]
+        particle_cluster_use_collision_hulls        "false" // REPLICATED CONVAR, MIGHT NEED TO MATCH WITH SERVER
+        r_RainParticleDensity                       "0"     // Density of Particle Rain 0-1.                                    [def: "1"]
+        r_citadel_screenspace_particles_full_res    "0"
+        r_draw_particle_children_with_parents       "0"     // I believe this handles the drawing of little visual flourish particles. [def: "-1"]
+        r_drawparticles                             "true"  // default: true - might change to false again
+        r_limit_particle_job_duration               "1"     // Seems to help with particle clutter, although I am not sure.             [def: "false"]
+        r_particle_batch_collections                "true"  // Batches collections of particles, typically batch rendering is faster so this is set to true. [def: "false"]
+        r_particle_cables_cast_shadows              "0"     // Disables shadow casting from cable/rope-like particle effects. [def: "1"]
+        r_particle_cables_render                    "false" // default true break lash ult, might need to set back to 1
+        r_particle_cables_render_meshlets           "0"
+        r_particle_max_detail_level                 "0"      // The maximum detail level of particle to create.                  [def: "3"]
+        r_particle_max_draw_distance                "300000" // Lower = less particle range, more FPS, dont go below this value it doesnt draw trooper hp bar,
+        r_particle_max_texture_layers               "4"      // Anything below 4 will make infernus afterburn, paige fire, and drifter's passive look very weird and blocky [def: "-1"]
+        r_particle_min_timestep                     "0.001"
+        r_particle_mixed_resolution_viewstart       "800"
+        r_particle_model_new8                       "0"  // Disables newer particle models. [def: "1"]
+        r_particle_model_per_thread_count           "32" // I believe it is how many particle models a thread is allowed to handle.  [def: "32"]
+        r_particle_skip_postsim                     "1"  // Not entirely sure what it does, going off of the name I'd imagine it skips the post simulation, this is a testvar [def: "false"]
+        r_physics_particle_op_spawn_scale           "0"  // Prevents physics-based particle spawns.                          [def: "1"]
+        r_world_wind_strength                       "0"  // Disables wind effects, cosmetic only.                            [def: "40"]
 
-// ================ Lod & Culling ================
-// r_propsmaxdist                            "100"           // default: 1200
-citadel_use_pvs_for_players                 "true"          // Default culls players when out of view                           [def: "false"]
-mat_viewportscale                           "1"             // Scale down the main viewport I belive this gets overwritten by video.txt [def: "1"]
-phys_cull_internal_mesh_contacts            "true"          // Don't simulate the bones inside of a mesh.                       [def: "false"]
-r_aoproxy_cull_dist                         "0.01"          // default: 12, might be able to do 0, idk
-r_aoproxy_min_dist                          "9999"          // default: 3, 0 is always tricky so consider changing this to 1
-r_aoproxy_min_dist_box                      "9999"          
-r_citadel_distancefield_down_sample         "6"             // default 1
-r_propsmaxdist                              "700"           
-r_strip_invisible_during_sceneobject_update "1"             // Default: false
-sc_aggregate_bvh_threshold                  "16"            // Not fully sure what these do. Don't change them.                 [def: "128"]
-sc_allow_dithered_lod                       "false"         // default: true
-sc_clutter_density_full_size                "0.5"           
-sc_clutter_density_none_size                "0.1"           // Default 0.0035
-sc_dithered_lod_transition_amt              "0"             
-sc_enable_discard                           "true"          // default true
-sc_fade_distance_scale_override             "180"           // Distance objects fade in and out                                 [def: "-1"]
-sc_instanced_mesh_lod_bias                  "15"            // Bias for LOD selection of instanced mesh                         [def: "1.25"]
-sc_instanced_mesh_mesh_shader               "false"         // default true Toggles mesh shader rendering for instanced meshes
-sc_instanced_mesh_motion_vectors            "0"             // Set 1 if you use motion blur                                     [def: "1"]
-sc_instanced_mesh_opaque_fade               "false"         
-sc_instanced_mesh_size_cull_bias            "10"            // Bias for size culling of instanced meshes                        [def: "1.5"]
-sc_layer_batch_threshold                    "16"            // Not fully sure what these do. Don't change them.                 [default: "128"]
-sc_layer_batch_threshold_fullsort           "20"            // Not sure what these do. Jasper said to leave them at default     [def: "80"]
-sc_max_framebuffer_copies_per_layer         "0"             // no idea what this does ngl
-sc_screen_size_lod_scale_override           "0.001"         // Controls LOD scale. Lower values will have less polys            [def: "-1"]
-sv_pvs_max_distance                         "8500"          // default 4000, unrender things(boxes, creeps, objs,etc) behind walls or out of viewing distance, does not affect player model.
-sv_remove_ent_from_pvs                      "1"             // default 0 remove entities from potential view something, basically culling objs outside of view
+        // ================ Lod & Culling ================
+        // r_propsmaxdist                           "100"  // default: 1200
+        citadel_use_pvs_for_players                 "true" // Default culls players when out of view                           [def: "false"]
+        mat_viewportscale                           "1"    // Scale down the main viewport I belive this gets overwritten by video.txt [def: "1"]
+        phys_cull_internal_mesh_contacts            "true" // Don't simulate the bones inside of a mesh.                       [def: "false"]
+        r_aoproxy_cull_dist                         "0.01" // default: 12, might be able to do 0, idk
+        r_aoproxy_min_dist                          "9999" // default: 3, 0 is always tricky so consider changing this to 1
+        r_aoproxy_min_dist_box                      "9999"
+        r_citadel_distancefield_down_sample         "6" // default 1
+        r_propsmaxdist                              "700"
+        r_strip_invisible_during_sceneobject_update "1"     // Default: false
+        sc_aggregate_bvh_threshold                  "16"    // Not fully sure what these do. Don't change them.                 [def: "128"]
+        sc_allow_dithered_lod                       "false" // default: true
+        sc_clutter_density_full_size                "0.5"
+        sc_clutter_density_none_size                "0.1" // Default 0.0035
+        sc_dithered_lod_transition_amt              "0"
+        sc_enable_discard                           "true"  // default true
+        sc_fade_distance_scale_override             "180"   // Distance objects fade in and out                                 [def: "-1"]
+        sc_instanced_mesh_lod_bias                  "15"    // Bias for LOD selection of instanced mesh                         [def: "1.25"]
+        sc_instanced_mesh_mesh_shader               "false" // default true Toggles mesh shader rendering for instanced meshes
+        sc_instanced_mesh_motion_vectors            "0"     // Set 1 if you use motion blur                                     [def: "1"]
+        sc_instanced_mesh_opaque_fade               "false"
+        sc_instanced_mesh_size_cull_bias            "10"    // Bias for size culling of instanced meshes                        [def: "1.5"]
+        sc_layer_batch_threshold                    "16"    // Not fully sure what these do. Don't change them.                 [default: "128"]
+        sc_layer_batch_threshold_fullsort           "20"    // Not sure what these do. Jasper said to leave them at default     [def: "80"]
+        sc_max_framebuffer_copies_per_layer         "0"     // no idea what this does ngl
+        sc_screen_size_lod_scale_override           "0.001" // Controls LOD scale. Lower values will have less polys            [def: "-1"]
+        sv_pvs_max_distance                         "8500"  // default 4000, unrender things(boxes, creeps, objs,etc) behind walls or out of viewing distance, does not affect player model.
+        sv_remove_ent_from_pvs                      "1"     // default 0 remove entities from potential view something, basically culling objs outside of view
 
-// ================ Misc ================
-// citadel_outer_radius_scaler               "0.25"          // I need to figure out what this does
-citadel_cinematic_intro_duration_npc        "0.01"          
-citadel_cinematic_intro_duration_player     "0.01"          
-citadel_cinematic_intro_enabled             "-1"            
-citadel_commend_toast_enemy_seconds         "0"             
-citadel_commend_toast_seconds               "0"             
-citadel_hideout_enable_testing_tools        "true"          // default false doesnt work
-citadel_match_details_lane_stats_time       "360"           
-cl_batch_entity_list_ops_during_latch       "1"             // Batch entity list adds / removes while latching interpolated variables to avoid mutex contention.    [def: "false"]
-cl_interp_parallel                          "1"             // Run interpolation in parallel for entities with no children.     [def: "false"]
-cl_phys_enabled                             "false"         // You can disable physics and might see an improvement in framerate, however a lot will be buggy.   [def: "true"]
-cl_phys_networked_start_sleep               "true"          // try on and off, this is probably what causing result screen to pop up when idling
-cl_phys_sleep_enable                        "1"             
-cl_phys_timescale                           "1"             // [FPS IMPACT] 0=Disable physics (max FPS) | 1=Normal physics | Lower = slower physics, less CPU
-cl_physics_highlight_active                 "0"             // Turns on the absbox for all active physics objects.  0 : un-highlight.
-cl_smooth                                   "true"          // might change to false again
-nav_obstruction_async_update                "true"          // Not fully sure but async good wowie                              [def: "false"]
-phys_dynamic_scaling                        "false"         // default true
-phys_expensive_shape_threshold              "100"           // default: 6
-phys_highlight_expensive_objects_strength   "0"             // Default: 0.02 Highlight expensive physics objects strength, no need since expensive obj is disabled by default
-phys_multithreading_enabled                 "1"             // default true, alr enabled no need to include ngl
-r_async_compute_fog                         "true"          // Just whether to asyncroniously render fog                        [def: "false"]
-r_citadel_depth_prepass_dynamic_objects     "false"         // Should be not prepassing entities that move                      [def: "true"]
-r_drawropes                                 "0"             // Draw ropes. [def: "1"]
-r_enable_rigid_animation                    "0"             
-r_max_portal_render_targets                 "2"             // Maxium number of Doorman doors to allow rendering.               [def: "0"]
-r_pipeline_stats_use_flush_api              "false"         
-r_render_portals                            "true"          // default: true
-r_renderdoc_auto_shader_pdbs                "0"             // Automatically generate shader debug info on capture.             [def: "true"]
-r_ropetranslucent                           "0"             // Disables translucent rope rendering. [def: "1"]
-r_translucent                               "true"          // default: true ; false gives fps but you cant see any trails, nor aoe effect, nothing
-rope_collide                                "0"             // Disables rope collision simulation. [def: "1"]
-rope_smooth_enlarge                         "0"             // How much to enlarge ropes in screen space for antialiasing effect. [def: "1.4"]
-rope_smooth_maxalpha                        "0"             // Alpha for rope antialiasing effect. [def: "0.5"]
-rope_smooth_maxalphawidth                   "0"             // Disables rope smoothing width-based alpha. [def: "1.75"]
-rope_smooth_minalpha                        "0"             // Disables rope minimum smoothing alpha. [def: "0.2"]
-rope_smooth_minwidth                        "0"             // Disables rope minimum smoothing width. [def: "0.3"]
-rope_subdiv                                 "0"             // Sets rope subdivision (0 = minimal geometry). [def: "2"]
-rope_wind_dist                              "0"             // Disables rope wind influence. [def: "1000"]
-sc_disable_baked_lighting                   "true"          // default: false
-sc_force_materials_batchable                "true"          // I would imagine this functions as the variable is named.         [def: "false"]
-sc_hdr_enabled_override                     "0"             // default: -1
-wind_system_default_resolution_xy           "64"            
-wind_system_temporal_smoothing              "false"         
-zipline_use_new_latch                       "0"             // Use the new latch motion for getting on a zipline. 0: Dont use 1: Just those with b_UseNewZipLineSetup 2: Everyone use. [def: "2"]
+        // ================ Misc ================
+        // citadel_outer_radius_scaler            "0.25" // I need to figure out what this does
+        citadel_cinematic_intro_duration_npc      "0.01"
+        citadel_cinematic_intro_duration_player   "0.01"
+        citadel_cinematic_intro_enabled           "-1"
+        citadel_commend_toast_enemy_seconds       "0"
+        citadel_commend_toast_seconds             "0"
+        citadel_hideout_enable_testing_tools      "true" // default false doesnt work
+        citadel_match_details_lane_stats_time     "360"
+        cl_batch_entity_list_ops_during_latch     "1"     // Batch entity list adds / removes while latching interpolated variables to avoid mutex contention.    [def: "false"]
+        cl_interp_parallel                        "1"     // Run interpolation in parallel for entities with no children.     [def: "false"]
+        cl_phys_enabled                           "false" // You can disable physics and might see an improvement in framerate, however a lot will be buggy.   [def: "true"]
+        cl_phys_networked_start_sleep             "true"  // try on and off, this is probably what causing result screen to pop up when idling
+        cl_phys_sleep_enable                      "1"
+        cl_phys_timescale                         "1"     // [FPS IMPACT] 0=Disable physics (max FPS) | 1=Normal physics | Lower = slower physics, less CPU
+        cl_physics_highlight_active               "0"     // Turns on the absbox for all active physics objects.  0 : un-highlight.
+        cl_smooth                                 "true"  // might change to false again
+        nav_obstruction_async_update              "true"  // Not fully sure but async good wowie                              [def: "false"]
+        phys_dynamic_scaling                      "false" // default true
+        phys_expensive_shape_threshold            "100"   // default: 6
+        phys_highlight_expensive_objects_strength "0"     // Default: 0.02 Highlight expensive physics objects strength, no need since expensive obj is disabled by default
+        phys_multithreading_enabled               "1"     // default true, alr enabled no need to include ngl
+        r_async_compute_fog                       "true"  // Just whether to asyncroniously render fog                        [def: "false"]
+        r_citadel_depth_prepass_dynamic_objects   "false" // Should be not prepassing entities that move                      [def: "true"]
+        r_drawropes                               "0"     // Draw ropes. [def: "1"]
+        r_enable_rigid_animation                  "0"
+        r_max_portal_render_targets               "2" // Maxium number of Doorman doors to allow rendering.               [def: "0"]
+        r_pipeline_stats_use_flush_api            "false"
+        r_render_portals                          "true" // default: true
+        r_renderdoc_auto_shader_pdbs              "0"    // Automatically generate shader debug info on capture.             [def: "true"]
+        r_ropetranslucent                         "0"    // Disables translucent rope rendering. [def: "1"]
+        r_translucent                             "true" // default: true ; false gives fps but you cant see any trails, nor aoe effect, nothing
+        rope_collide                              "0"    // Disables rope collision simulation. [def: "1"]
+        rope_smooth_enlarge                       "0"    // How much to enlarge ropes in screen space for antialiasing effect. [def: "1.4"]
+        rope_smooth_maxalpha                      "0"    // Alpha for rope antialiasing effect. [def: "0.5"]
+        rope_smooth_maxalphawidth                 "0"    // Disables rope smoothing width-based alpha. [def: "1.75"]
+        rope_smooth_minalpha                      "0"    // Disables rope minimum smoothing alpha. [def: "0.2"]
+        rope_smooth_minwidth                      "0"    // Disables rope minimum smoothing width. [def: "0.3"]
+        rope_subdiv                               "0"    // Sets rope subdivision (0 = minimal geometry). [def: "2"]
+        rope_wind_dist                            "0"    // Disables rope wind influence. [def: "1000"]
+        sc_disable_baked_lighting                 "true" // default: false
+        sc_force_materials_batchable              "true" // I would imagine this functions as the variable is named.         [def: "false"]
+        sc_hdr_enabled_override                   "0"    // default: -1
+        wind_system_default_resolution_xy         "64"
+        wind_system_temporal_smoothing            "false"
+        zipline_use_new_latch                     "0" // Use the new latch motion for getting on a zipline. 0: Dont use 1: Just those with b_UseNewZipLineSetup 2: Everyone use. [def: "2"]
 
-// ================ Grass ================
-r_grass_end_fade                            "0"             // When to cull grass when far                                      [def: "300"]
-r_grass_quality                             "0"             // Quality of the grass                                             [def: "2"]
-r_grass_start_fade                          "0"             // When to cull grass when it's close I think                       [def: "0"]
-r_world_wind_frequency_grass                "0"             
-r_world_wind_frequency_trees                "0"             
+        // ================ Grass ================
+        r_grass_end_fade             "0" // When to cull grass when far                                      [def: "300"]
+        r_grass_quality              "0" // Quality of the grass                                             [def: "2"]
+        r_grass_start_fade           "0" // When to cull grass when it's close I think                       [def: "0"]
+        r_world_wind_frequency_grass "0"
+        r_world_wind_frequency_trees "0"
 
-// ================ Creep AI ================
-// ai_lod_auto_enabled                       "1"             // Default 0, idk about this
-ai_async_queue_max_jobs                     "1"             
-ai_expression_optimization                  "1"             
-ai_foot_sweep_enable                        "false"         
-ai_gather_conditions_async                  "true"          // default false
-ai_strong_optimizations_no_checkstand       "1"             // Not fully sure what exactly this does, but I would imagine given the name of the convar it optimizes ai. [def: "0"]
-ai_think_interval                           "0.3"           
-ai_think_interval_lod_low                   "1"             
-citadel_npc_disable_cockroaches             "true"          
-citadel_npc_disable_floor_point_caching     "false"         
-citadel_npc_force_animate_every_tick        "false"         // Don't change this, it does what it says on the tin.              [def: "true"]
-cl_simulate_dormant_entities                "0"             // Based on the name I would imagine it does what it says.          [def: "true"]
-nav_pathfind_multithread                    "1"             // default false test 1 and 0, moves npc pathing to separate thread
+        // ================ Creep AI ================
+        // ai_lod_auto_enabled                  "1" // Default 0, idk about this
+        ai_async_queue_max_jobs                 "1"
+        ai_expression_optimization              "1"
+        ai_foot_sweep_enable                    "false"
+        ai_gather_conditions_async              "true" // default false
+        ai_strong_optimizations_no_checkstand   "1"    // Not fully sure what exactly this does, but I would imagine given the name of the convar it optimizes ai. [def: "0"]
+        ai_think_interval                       "0.3"
+        ai_think_interval_lod_low               "1"
+        citadel_npc_disable_cockroaches         "true"
+        citadel_npc_disable_floor_point_caching "false"
+        citadel_npc_force_animate_every_tick    "false" // Don't change this, it does what it says on the tin.              [def: "true"]
+        cl_simulate_dormant_entities            "0"     // Based on the name I would imagine it does what it says.          [def: "true"]
+        nav_pathfind_multithread                "1"     // default false test 1 and 0, moves npc pathing to separate thread
 
-// ================ Audio ================
-audio_enable_vmix_mastering                 "0"             // Whether the engine uses vmix to master the audio, might be a dev command [def: "true"]
-dsp_slow_cpu                                "1"             
-dsp_volume                                  "0"             // idk
-snd_mix_async                               "1"             
-snd_mixahead                                "0.05"          // Adds some latency that shouldn't be percivable to save cpu       [def: "0.001"]
-snd_occlusion_bounces                       "0"             // Limits audio occlusion to save cpu                               [def: "1"]
-snd_spatialize_lerp                         "0"             
-snd_steamaudio_enable_perspective_correction "0"            
-snd_steamaudio_enable_reverb                "0"             
-snd_steamaudio_num_threads                  "4"             // Audio thread count                                               [def: "4"]
-snd_use_baked_occlusion                     "1"             
-soundsystem_update_async                    "1"             
-update_voices_low_priority                  "true"          // default false
+        // ================ Audio ================
+        audio_enable_vmix_mastering                  "0" // Whether the engine uses vmix to master the audio, might be a dev command [def: "true"]
+        dsp_slow_cpu                                 "1"
+        dsp_volume                                   "0" // idk
+        snd_mix_async                                "1"
+        snd_mixahead                                 "0.05" // Adds some latency that shouldn't be percivable to save cpu       [def: "0.001"]
+        snd_occlusion_bounces                        "0"    // Limits audio occlusion to save cpu                               [def: "1"]
+        snd_spatialize_lerp                          "0"
+        snd_steamaudio_enable_perspective_correction "0"
+        snd_steamaudio_enable_reverb                 "0"
+        snd_steamaudio_num_threads                   "4" // Audio thread count                                               [def: "4"]
+        snd_use_baked_occlusion                      "1"
+        soundsystem_update_async                     "1"
+        update_voices_low_priority                   "true" // default false
 
-// ================ Csm Shadows. ================
-csm_cascade0_override_dist                  "0"             // All of these commands should reduce shadow quality.
-csm_cascade1_override_dist                  "0"             // All of these commands should reduce shadow quality.
-csm_cascade2_override_dist                  "0"             // All of these commands should reduce shadow quality.
-csm_cascade3_override_dist                  "0"             // All of these commands should reduce shadow quality.
-csm_max_dist_between_caster_and_receiver    "0"             // All of these commands should reduce shadow quality.
-csm_max_num_cascades_override               "0"             // All of these commands should reduce shadow quality.
-csm_max_shadow_dist_override                "0"             // All of these commands should reduce shadow quality.
-csm_max_visible_dist                        "0"             // All of these commands should reduce shadow quality.
-csm_res_override_0                          "1"             // All of these commands should reduce shadow quality.
-csm_res_override_1                          "1"             // All of these commands should reduce shadow quality.
-csm_res_override_2                          "1"             // All of these commands should reduce shadow quality.
-csm_res_override_3                          "1"             // All of these commands should reduce shadow quality.
-csm_viewmodel_shadows                       "false"         // All of these commands should reduce shadow quality.
+        // ================ Csm Shadows. ================
+        csm_cascade0_override_dist               "0"     // All of these commands should reduce shadow quality.
+        csm_cascade1_override_dist               "0"     // All of these commands should reduce shadow quality.
+        csm_cascade2_override_dist               "0"     // All of these commands should reduce shadow quality.
+        csm_cascade3_override_dist               "0"     // All of these commands should reduce shadow quality.
+        csm_max_dist_between_caster_and_receiver "0"     // All of these commands should reduce shadow quality.
+        csm_max_num_cascades_override            "0"     // All of these commands should reduce shadow quality.
+        csm_max_shadow_dist_override             "0"     // All of these commands should reduce shadow quality.
+        csm_max_visible_dist                     "0"     // All of these commands should reduce shadow quality.
+        csm_res_override_0                       "1"     // All of these commands should reduce shadow quality.
+        csm_res_override_1                       "1"     // All of these commands should reduce shadow quality.
+        csm_res_override_2                       "1"     // All of these commands should reduce shadow quality.
+        csm_res_override_3                       "1"     // All of these commands should reduce shadow quality.
+        csm_viewmodel_shadows                    "false" // All of these commands should reduce shadow quality.
 
-//  Major thanks to all of these individuals from the bottom of my heart. They are all lovely.
-//- Sqooky:             I am the primary developer and maintainer of the project, but without everyone else here this project would not be maintained to this degree
-//- JasperP:            My personal hero.  
-//- Artemon121:         Made the Citadel cvar unhider, which helped Abdalla fetch cvars and test in-game.  
-//- Boot:               Provided the csm cvars which had a notable performance improvement.  
-//- Brullee:            Removed fake cvars, redundant commands, added cvarlist.md, and reformatted config  
-//- Dacooder:           Made a wonderful video highlighting me and the config.  
-//- Kaizuchaneru:       While not directly invovled in the deveopment, they tested most cvars  
-//- Kin:                Did an insane amount of benchmarking unprompted.  
-//- Maihdenless:        Started the original OptimisationLock & its Discord.  
-//- Piggy:              Let me mirror his config.  
-//- Soulx:              Gave me five dollars and told me about spirolactone (fucking sick I love you)
-//- Tamara Mochaccina:  Contributed vindicta scope fix and the fog fix.  
+        //  Major thanks to all of these individuals from the bottom of my heart. They are all lovely.
+        //- Sqooky:             I am the primary developer and maintainer of the project, but without everyone else here this project would not be maintained to this degree
+        //- JasperP:            My personal hero.
+        //- Artemon121:         Made the Citadel cvar unhider, which helped Abdalla fetch cvars and test in-game.
+        //- Boot:               Provided the csm cvars which had a notable performance improvement.
+        //- Brullee:            Removed fake cvars, redundant commands, added cvarlist.md, and reformatted config
+        //- Dacooder:           Made a wonderful video highlighting me and the config.
+        //- Kaizuchaneru:       While not directly invovled in the deveopment, they tested most cvars
+        //- Kin:                Did an insane amount of benchmarking unprompted.
+        //- Maihdenless:        Started the original OptimisationLock & its Discord.
+        //- Piggy:              Let me mirror his config.
+        //- Soulx:              Gave me five dollars and told me about spirolactone (fucking sick I love you)
+        //- Tamara Mochaccina:  Contributed vindicta scope fix and the fog fix.
 
-// Cool people I've met because of this project who I want to thank anyway
-//- 6Daves
-//- Anartoast
-//- Boot
-//- GoreDaughter
-//- Jaden
-//- Jasper
-//- Jb
-//- Kin
-//- Krisha
-//- Masteroms
-//- PeachCebo
-//- Tamara Mochaccina
-//- And you, thank you for using this and making my day <3. Please take care of yourselves.
-// --------------------------------- END OF CONFIG OptimizationLock -- ver. 2 ------------------------------- \\
+        // Cool people I've met because of this project who I want to thank anyway
+        //- 6Daves
+        //- Anartoast
+        //- Boot
+        //- GoreDaughter
+        //- Jaden
+        //- Jasper
+        //- Jb
+        //- Kin
+        //- Krisha
+        //- Masteroms
+        //- PeachCebo
+        //- Tamara Mochaccina
+        //- And you, thank you for using this and making my day <3. Please take care of yourselves.
+        // --------------------------------- END OF CONFIG OptimizationLock -- ver. 2 ------------------------------- \\
 
-        "rate"
+        rate
         {
-            "min"       "98304"
-            "default"   "786432"
-            "max"       "1000000"
+            min     "98304"
+            default "786432"
+            max     "1000000"
         }
-        "sv_minrate"    "98304"
-        "sv_maxunlag"   "0.500"
-        "sv_maxunlag_player" "0.200"
-        "sv_lagcomp_filterbyviewangle" "false"
+        sv_minrate                   "98304"
+        sv_maxunlag                  "0.500"
+        sv_maxunlag_player           "0.200"
+        sv_lagcomp_filterbyviewangle "false"
 
         // Spew warning when adding/removing classes to/from the top of the hierarchy
-        "panorama_classes_perf_warning_threshold_ms" "0.75"
+        panorama_classes_perf_warning_threshold_ms "0.75"
 
         // Panorama - enable minidumps on JS exceptions
-        "panorama_js_minidumps" "1"
+        panorama_js_minidumps "1"
         // Enable the render target cache optimization.
-        "panorama_disable_render_target_cache" "0"
+        panorama_disable_render_target_cache "0"
 
         // Enable the composition layer optimization
-        "panorama_skip_composition_layer_content_paint" "1"
+        panorama_skip_composition_layer_content_paint "1"
 
         // too expensive (500MB+) to load this
-        "snd_steamaudio_load_reverb_data" "0"
-        "snd_steamaudio_load_pathing_data" "0"
+        snd_steamaudio_load_reverb_data  "0"
+        snd_steamaudio_load_pathing_data "0"
 
         // Steam Audio project specific convars
-        "snd_steamaudio_enable_custom_hrtf"     "0"
-        "snd_steamaudio_active_hrtf"            "0"
-        "snd_steamaudio_reverb_update_rate"     "10.0"
-        "snd_steamaudio_ir_duration"            "1.0"
-        "snd_steamaudio_enable_pathing"         "0"
-        "snd_steamaudio_invalid_path_length"    "0.0"
-        "cl_disconnect_soundevent"              "citadel.convar.stop_all_game_layer_soundevents"
-        "snd_event_browser_default_stack"       "citadel_default_3d"
+        snd_steamaudio_enable_custom_hrtf  "0"
+        snd_steamaudio_active_hrtf         "0"
+        snd_steamaudio_reverb_update_rate  "10.0"
+        snd_steamaudio_ir_duration         "1.0"
+        snd_steamaudio_enable_pathing      "0"
+        snd_steamaudio_invalid_path_length "0.0"
+        cl_disconnect_soundevent           "citadel.convar.stop_all_game_layer_soundevents"
+        snd_event_browser_default_stack    "citadel_default_3d"
 
         // voip
-        "voice_in_process"                      "1"
+        voice_in_process "1"
 
         // Sound debugging
-        "snd_report_audio_nan" "1"
+        snd_report_audio_nan "1"
 
         // Audio system settings
-        "snd_sos_max_event_base_depth" "10"
-        "sos_use_guid_filter" "1"
+        snd_sos_max_event_base_depth "10"
+        sos_use_guid_filter          "1"
 
-        "voice_always_sample_mic"
+        voice_always_sample_mic
         {
-            "version"   "2"
-            "default"   "0"
+            version "2"
+            default "0"
         }
 
-        "reset_voice_on_input_stallout"         "0"
-        "voice_input_stallout"                  "0.5"
-        "cl_usesocketsforloopback" "1"
-        "cl_poll_network_early" "0"
+        reset_voice_on_input_stallout "0"
+        voice_input_stallout          "0.5"
+        cl_usesocketsforloopback      "1"
+        cl_poll_network_early         "0"
 
         // Perf/Parallelism
-        "iv_parallel_restore" "1" // EDITED BY BOOT
+        iv_parallel_restore "1" // EDITED BY BOOT
 
         // For perf reasons, since we don't use source-based DSP:
-        "disable_source_soundscape_trace"       "1"
+        disable_source_soundscape_trace "1"
 
         // Networking - Induced latency (pred offset)
-        "cl_tickpacket_recvmargin_desired" "5"                  // 5 ms base, min. floor for protecting against thrashing the queue
-        "cl_tickpacket_desired_queuelength" "0"                 // 0 = attempt to always reach the queue's min floor
-        "cl_async_usercmd_send_disabled_recvmargin_min" "0.5"   // Additional frame since we do not use the async usercmd send (potentially unneccessary)
-        "cl_clock_buffer_ticks" "1"
-        "cl_interp_ratio" "0"
-        "cl_async_usercmd_send" "true"
+        cl_tickpacket_recvmargin_desired              "5"   // 5 ms base, min. floor for protecting against thrashing the queue
+        cl_tickpacket_desired_queuelength             "0"   // 0 = attempt to always reach the queue's min floor
+        cl_async_usercmd_send_disabled_recvmargin_min "0.5" // Additional frame since we do not use the async usercmd send (potentially unneccessary)
+        cl_clock_buffer_ticks                         "1"
+        cl_interp_ratio                               "0"
+        cl_async_usercmd_send                         "true"
 
-        "fps_max"       "0"
-        "fps_max_ui"    "120"
+        fps_max    "0"
+        fps_max_ui "120"
 
-        "in_button_double_press_window" "0.3"
+        in_button_double_press_window "0.3"
 
         // Convars that control spatialization of UI audio.
-        "snd_ui_positional"                             "1"
-        "snd_ui_spatialization_spread"                  "2.4"
+        snd_ui_positional            "1"
+        snd_ui_spatialization_spread "2.4"
 
         // sound volume rate change limiting
-        "snd_envelope_rate"                             "100.0"
-        "snd_soundmixer_update_maximum_frame_rate"      "0"
+        snd_envelope_rate                        "100.0"
+        snd_soundmixer_update_maximum_frame_rate "0"
 
         //don't let people mess with speaker config settings.
-        "speaker_config"
+        speaker_config
         {
-            "min"       "0"
-            "default"   "0"
-            "max"       "2"
+            min     "0"
+            default "0"
+            max     "2"
         }
 
-        "cq_buffer_bloat_msecs_max" "120"
+        cq_buffer_bloat_msecs_max "120"
 
-        "snd_soundmixer"                        "Default_Mix"
-        "cloth_filter_transform_stateless" "0"
+        snd_soundmixer                   "Default_Mix"
+        cloth_filter_transform_stateless "0"
 
-        "cl_joystick_enabled" "0"
-        "panorama_joystick_enabled" "0"
+        cl_joystick_enabled       "0"
+        panorama_joystick_enabled "0"
 
-        "snd_event_browser_focus_events" "true"
+        snd_event_browser_focus_events "true"
 
-        "cl_max_particle_pvs_aabb_edge_length" "100"
+        cl_max_particle_pvs_aabb_edge_length "100"
 
         // Allow aggregation of particles (for perf)
-        "cl_aggregate_particles" "true"
+        cl_aggregate_particles "true"
 
-        "citadel_enable_vdata_sound_preload" "true"
+        citadel_enable_vdata_sound_preload "true"
 
-        "r_particle_allowprerender" "false"
+        r_particle_allowprerender "false"
     }
 
     Memory
     {
-        "EstimatedMaxCPUMemUsageMB" "1"
-        "EstimatedMinGPUMemUsageMB" "1"
+        EstimatedMaxCPUMemUsageMB "1"
+        EstimatedMinGPUMemUsageMB "1"
 
-        "ShowInsufficientPageFileMessageBox" "1"
-        "ShowLowAvailableVirtualMemoryMessageBox" "1"
+        ShowInsufficientPageFileMessageBox      "1"
+        ShowLowAvailableVirtualMemoryMessageBox "1"
     }
 }

--- a/clean gameinfo.gi/gameinfo.gi
+++ b/clean gameinfo.gi/gameinfo.gi
@@ -1,589 +1,588 @@
-"GameInfo"
+GameInfo
 {
-	game 		"citadel"
-	title 		"Citadel"
-	type		multiplayer_only
-	nomodels 1
-	nohimodel 1
-	nocrosshair 0
-	hidden_maps
-	{
-		"test_speakers"			1
-		"test_hardware"			1
-	}
-	nodegraph 0
-	perfwizard 0
-	tonemapping 0
-	GameData	"citadel.fgd"
+    game        "citadel"
+    title       "Citadel"
+    type        "multiplayer_only"
+    nomodels    "1"
+    nohimodel   "1"
+    nocrosshair "0"
+    hidden_maps
+    {
+        test_speakers "1"
+        test_hardware "1"
+    }
+    nodegraph   "0"
+    perfwizard  "0"
+    tonemapping "0"
+    GameData    "citadel.fgd"
 
-	DisallowGameInfoConditionals 1
-	PGIVersion "6E09D3ED5A47F6A97443813F0E00F90BAA435918F82DF0C9B5DA46D27A33D903"
+    DisallowGameInfoConditionals "1"
+    PGIVersion                   "6E09D3ED5A47F6A97443813F0E00F90BAA435918F82DF0C9B5DA46D27A33D903"
 
-	Localize
-	{
-		DuplicateTokensAssert	1
-		DisallowTokenContexts	1
-	}
+    Localize
+    {
+        DuplicateTokensAssert "1"
+        DisallowTokenContexts "1"
+    }
 
-	SupportedLanguages
-	{
-		"brazilian" "3"
-		"czech" "3"
-		"english" "3"
-		"french" "3"
-		"german" "3"
-		"italian" "3"
-		"indonesian" "3"
-		"japanese" "3"
-		"koreana" "3"
-		"latam" "3"
-		"polish" "3"
-		"russian" "3"
-		"schinese" "3"
-		"spanish" "3"
-		"thai" "3"
-		"turkish" "3"
-		"ukrainian" "3"
-	}
-	
-	FileSystem
-	{	
-		//
-		// The code that loads this file automatically does a few things here:
-		//
-		// 1. For each "Game" search path, it adds a "GameBin" path, in <dir>\bin
-		// 2. For each "Game" search path, it adds another "Game" path in front of it with _<language> at the end.
-		//    For example: c:\hl2\cstrike on a french machine would get a c:\hl2\cstrike_french path added to it.
-		// 3. If no "Mod" key, for the first "Game" search path, it adds a search path called "MOD".
-		// 4. If no "Write" key, for the first "Game" search path, it adds a search path called "DEFAULT_WRITE_PATH".
-		//
+    SupportedLanguages
+    {
+        brazilian  "3"
+        czech      "3"
+        english    "3"
+        french     "3"
+        german     "3"
+        italian    "3"
+        indonesian "3"
+        japanese   "3"
+        koreana    "3"
+        latam      "3"
+        polish     "3"
+        russian    "3"
+        schinese   "3"
+        spanish    "3"
+        thai       "3"
+        turkish    "3"
+        ukrainian  "3"
+    }
 
-		//
-		// Search paths are relative to the exe directory\..\
-		//
-		SearchPaths
-		{
-			// These are optional language paths. They must be mounted first, which is why there are first in the list.
-			// *LANGUAGE* will be replaced with the actual language name. If not running a specific language, these paths will not be mounted
-			Game_Language		citadel_*LANGUAGE*
+    FileSystem
+    {
+        //
+        // The code that loads this file automatically does a few things here:
+        //
+        // 1. For each "Game" search path, it adds a "GameBin" path, in <dir>\bin
+        // 2. For each "Game" search path, it adds another "Game" path in front of it with _<language> at the end.
+        //    For example: c:\hl2\cstrike on a french machine would get a c:\hl2\cstrike_french path added to it.
+        // 3. If no "Mod" key, for the first "Game" search path, it adds a search path called "MOD".
+        // 4. If no "Write" key, for the first "Game" search path, it adds a search path called "DEFAULT_WRITE_PATH".
+        //
 
-			// These are optional low-violence paths. They will only get mounted if you're in a low-violence mode.
-			Game_LowViolence	citadel_lv
+        //
+        // Search paths are relative to the exe directory\..\
+        //
+        SearchPaths
+        {
+            // These are optional language paths. They must be mounted first, which is why there are first in the list.
+            // *LANGUAGE* will be replaced with the actual language name. If not running a specific language, these paths will not be mounted
+            Game_Language "citadel_*LANGUAGE*"
 
-			Game				citadel
-			Game				core
-		}
-	}
-	
-	MaterialSystem2
-	{
-		RenderModes
-		{
-			game Default
-			game Forward
-			game Deferred
-			game Outline
-			game Depth
-			game FrontDepth
+            // These are optional low-violence paths. They will only get mounted if you're in a low-violence mode.
+            Game_LowViolence "citadel_lv"
 
-			dev ToolsVis // Visualization modes for all shaders (lighting only, normal maps only, etc.)
-			dev ToolsWireframe // This should use the ToolsVis mode above instead of being its own mode\
+            Game "citadel"
+            Game "core"
+        }
+    }
 
-			tools ToolsUtil // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
-		}
-	}
+    MaterialSystem2
+    {
+        RenderModes
+        {
+            game "Default"
+            game "Forward"
+            game "Deferred"
+            game "Outline"
+            game "Depth"
+            game "FrontDepth"
 
-	MaterialEditor
-	{
-		"DefaultShader" "environment_texture_set"
-	}
+            dev "ToolsVis"       // Visualization modes for all shaders (lighting only, normal maps only, etc.)
+            dev "ToolsWireframe" // This should use the ToolsVis mode above instead of being its own mode\
 
-	NetworkSystem
-	{
-		BetaUniverse
-		{
-			FakeLag			40
-			FakeLoss		.1
-			//FakeReorderPct 0.05
-			//FakeReorderDelay 10
-			//FakeJitter "low"
-			// Turning off fake jitter for now while I work on making the CQ totally solid
-			FakeReorderPct 0
-			FakeReorderDelay 0
-			FakeJitter "off"
-		}
+            tools "ToolsUtil" // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
+        }
+    }
 
-		"SkipRedundantChangeCallbacks"	"1"
-	}
+    MaterialEditor
+    {
+        DefaultShader "environment_texture_set"
+    }
 
-	RenderSystem
-	{
-		IndexBufferPoolSizeMB 32
-		UseReverseDepth 1
-		Use32BitDepthBuffer 0
-		Use32BitDepthBufferWithoutStencil 0
-		SwapChainSampleableDepth 1
-		VulkanMutableSwapchain 1
-		"LowLatency"								"1"
-		"VulkanOnly_Linux"							"1"
-		"VulkanRequireSubgroupWaveOpSupport"		"1"
-		"VulkanRequireDescriptorIndexing"			"1"
-		"VulkanSteamShaderCache" "1"
-		"VulkanSteamAppShaderCache" "1"
-		"VulkanSteamDownloadedShaderCache" "1"
-		"VulkanAdditionalShaderCache" "vulkan_shader_cache.foz"
-		"VulkanStagingPMBSizeLimitMB" "384"
-		"GraphicsPipelineLibrary"	"1"
-		"VulkanOnlyTestProbability" "0"
-		"VulkanDefrag"				"1"
-		"MinStreamingPoolSizeMB"	"1024"
-		"MinStreamingPoolSizeMBTools" "2048"
-	}
+    NetworkSystem
+    {
+        BetaUniverse
+        {
+            FakeLag             "40"
+            FakeLoss            ".1"
+            // FakeReorderPct   "0.05"
+            // FakeReorderDelay "10"
+            // FakeJitter       "low"
+            // Turning off fake jitter for now while I work on making the CQ totally solid
+            FakeReorderPct   "0"
+            FakeReorderDelay "0"
+            FakeJitter       "off"
+        }
 
-	NVNGX
-	{
-		AppID 103371621
-		SupportsDLSS 1
-	}
+        SkipRedundantChangeCallbacks "1"
+    }
 
-	Engine2
-	{
-		HasModAppSystems 1
-		Capable64Bit 1
-		URLName citadel
-		RenderingPipeline
-		{
-			SupportsMSAA 0
-			DistanceField 1
-		}
-		PauseSinglePlayerOnGameOverlay 1
-		DefensiveConCommands 1
-		DisableLoadingPlaque 1
-	}
+    RenderSystem
+    {
+        IndexBufferPoolSizeMB              "32"
+        UseReverseDepth                    "1"
+        Use32BitDepthBuffer                "0"
+        Use32BitDepthBufferWithoutStencil  "0"
+        SwapChainSampleableDepth           "1"
+        VulkanMutableSwapchain             "1"
+        LowLatency                         "1"
+        VulkanOnly_Linux                   "1"
+        VulkanRequireSubgroupWaveOpSupport "1"
+        VulkanRequireDescriptorIndexing    "1"
+        VulkanSteamShaderCache             "1"
+        VulkanSteamAppShaderCache          "1"
+        VulkanSteamDownloadedShaderCache   "1"
+        VulkanAdditionalShaderCache        "vulkan_shader_cache.foz"
+        VulkanStagingPMBSizeLimitMB        "384"
+        GraphicsPipelineLibrary            "1"
+        VulkanOnlyTestProbability          "0"
+        VulkanDefrag                       "1"
+        MinStreamingPoolSizeMB             "1024"
+        MinStreamingPoolSizeMBTools        "2048"
+    }
 
-	ContentBuilder
-	{
-		ResourceCompilerDirectXUsesWARP "0"
-	}
+    NVNGX
+    {
+        AppID        "103371621"
+        SupportsDLSS "1"
+    }
 
-	SoundSystem
-	{
-		SteamAudioEnabled            "1"
-		WaveDataCacheSizeMB          "256"
-		"UsePlatTime"            "1"
-	}
-	Sounds
-	{
-		HierarchicalEncodingFiles	 "1"
-	}
+    Engine2
+    {
+        HasModAppSystems "1"
+        Capable64Bit     "1"
+        URLName          "citadel"
+        RenderingPipeline
+        {
+            SupportsMSAA  "0"
+            DistanceField "1"
+        }
+        PauseSinglePlayerOnGameOverlay "1"
+        DefensiveConCommands           "1"
+        DisableLoadingPlaque           "1"
+    }
 
-	ToolsEnvironment
-	{
-		"Engine"	"Source 2"
-		"ToolsDir"	"../sdktools"	// NOTE: Default Tools path. This is relative to the mod path.
-	}
-	
-	pulse
-	{
-		"pulse_enabled"					"1"
-	}
+    ContentBuilder
+    {
+        ResourceCompilerDirectXUsesWARP "0"
+    }
 
-	Hammer
-	{
-		"fgd"					"citadel.fgd"	// NOTE: This is relative to the 'game' path.
-		"GameFeatureSet"		"Citadel"
-		"DefaultSolidEntity"	"trigger_multiple"
-		"DefaultPointEntity"	"info_player_start"
-		"NavMarkupEntity"		"func_nav_markup"
-		"OverlayBoxSize"			"8"
-		"TileMeshesEnabled"			"1"
-		"RenderMode"				"ToolsVis"
-		"CreateRenderClusters"		"1"
-		"DefaultMinDrawVolumeSize"	"2048"
-		"DefaultMinTrianglesPerCluster"	"16384"
-		"TileGridSupportsBlendHeight"	"1"
-		"TileGridBlendDefaultColor"	"0 255 0"
-		"LoadScriptEntities" "0"
-		"UsesBakedLighting" "1"
-		"UseAnalyticGrid" "0"
-		"SupportsDisplacementMapping" "0"
-		"SteamAudioEnabled"				"1"
-		"LatticeDeformerEnabled"		"1"
-		"ShadowAtlasWidth" "16384"
-		"ShadowAtlasHeight" "16384"
-		"TimeSlicedShadowMapRendering" "1"
-	}
+    SoundSystem
+    {
+        SteamAudioEnabled   "1"
+        WaveDataCacheSizeMB "256"
+        UsePlatTime         "1"
+    }
+    Sounds
+    {
+        HierarchicalEncodingFiles "1"
+    }
 
-	SoundTool
-	{
-		"DefaultSoundEventType" "src1_3d"
+    ToolsEnvironment
+    {
+        Engine   "Source 2"
+        ToolsDir "../sdktools" // NOTE: Default Tools path. This is relative to the mod path.
+    }
 
-		SoundEventBaseOptions
-		{
-			"Base.Announcer.VO.2d" ""
-			"Base.World.VO.Emitter.3d" ""
-			"Base.Hero.VO.Ping.2d" ""
-			"Base.Hero.VO.2d" ""
-			"Base.Hero.VO.3d" ""
-			"Base.Hero.VO.Ability.3d" ""
-			"Base.Hero.VO.Ultimate.3d" ""
-			"Base.Hero.VO.Dash.3d" ""
-			"Base.Hero.VO.Effort.3d" ""
-			"Base.Hero.VO.Pain.3d" ""
-			"Base.Hero.VO.Melee.3d" ""
-			"Base.Hero.VO.Death.3d" ""
-		}
-	}
+    pulse
+    {
+        pulse_enabled "1"
+    }
 
-	RenderPipelineAliases
-	{
-	}
+    Hammer
+    {
+        fgd                           "citadel.fgd" // NOTE: This is relative to the 'game' path.
+        GameFeatureSet                "Citadel"
+        DefaultSolidEntity            "trigger_multiple"
+        DefaultPointEntity            "info_player_start"
+        NavMarkupEntity               "func_nav_markup"
+        OverlayBoxSize                "8"
+        TileMeshesEnabled             "1"
+        RenderMode                    "ToolsVis"
+        CreateRenderClusters          "1"
+        DefaultMinDrawVolumeSize      "2048"
+        DefaultMinTrianglesPerCluster "16384"
+        TileGridSupportsBlendHeight   "1"
+        TileGridBlendDefaultColor     "0 255 0"
+        LoadScriptEntities            "0"
+        UsesBakedLighting             "1"
+        UseAnalyticGrid               "0"
+        SupportsDisplacementMapping   "0"
+        SteamAudioEnabled             "1"
+        LatticeDeformerEnabled        "1"
+        ShadowAtlasWidth              "16384"
+        ShadowAtlasHeight             "16384"
+        TimeSlicedShadowMapRendering  "1"
+    }
 
-	ResourceCompiler
-	{
-		// Overrides of the default builders as specified in code, this controls which map builder steps
-		// will be run when resource compiler is run for a map without specifiying any specific map builder
-		// steps. Additionally this controls which builders are displayed in the hammer build dialog.
-		DefaultMapBuilders
-		{
-			"bakedlighting"	"1"	// Enable lightmapping during compile time		
-			"envmap"	"0" // turned off since it currently causes an assert and doesn't work due to some build issue
-			"nav"		"1"	// Generate nav mesh data
-		}
+    SoundTool
+    {
+        DefaultSoundEventType "src1_3d"
 
-		MeshCompiler
-		{
-			OptimizeForMeshlets 1
-			TrianglesPerMeshlet 64	// Maximum valid value currently is 126
-			UseMikkTSpace 1
-			EncodeVertexBuffer 1
-            EncodeVertexBufferVersion 1
-            EncodeVertexBufferLevel 3
-			EncodeIndexBuffer 1
-			SplitDepthStream 1
-		}
+        SoundEventBaseOptions
+        {
+            Base.Announcer.VO.2d     ""
+            Base.World.VO.Emitter.3d ""
+            Base.Hero.VO.Ping.2d     ""
+            Base.Hero.VO.2d          ""
+            Base.Hero.VO.3d          ""
+            Base.Hero.VO.Ability.3d  ""
+            Base.Hero.VO.Ultimate.3d ""
+            Base.Hero.VO.Dash.3d     ""
+            Base.Hero.VO.Effort.3d   ""
+            Base.Hero.VO.Pain.3d     ""
+            Base.Hero.VO.Melee.3d    ""
+            Base.Hero.VO.Death.3d    ""
+        }
+    }
 
-		WorldRendererBuilder
-		{
-			VisibilityGuidedMeshClustering      "1"
-			MinimumTrianglesPerClusteredMesh    "8192"
-			MinimumVerticesPerClusteredMesh     "8192"
-			MinimumVolumePerClusteredMesh       "8192"       // ~20x20x20 cube
-			MaxPrecomputedVisClusterMembership  "96"
-			MaxCullingBoundsGroups              "128"
-			UseAggregateInstances				"1"
-			AggregateInstancingMeshlets			"1"
-			BakePropsWithExtraVertexStreams		"1"
-		}
+    RenderPipelineAliases
+    {
+    }
 
-		BakedLighting
-		{
-			Version 4
-			ImportanceVolumeTransitionRegion 512            // distance we transition from high to low resolution charts 
-			LightmapChannels
-			{
-				direct_light_shadows 1
-				debug_chart_color 1
-				directional_irradiance_sh2_dc 1
-				
-				directional_irradiance_sh2_r
-				{
-					CompressedFormat DXT1
-				}
-				
-				directional_irradiance_sh2_g
-				{
-					CompressedFormat DXT1
-				}
-				
-				directional_irradiance_sh2_b
-				{
-					CompressedFormat DXT1
-				}
-			}
-			LightmapGutterSize 2 // For bicubic filtering
-			UseStaticLightProbes 0
-			LPVAtlas 1
-			BC6HHueShiftFixup 0 // Causes more artifacts than it solves atm
-			Repack2 1
-		}
+    ResourceCompiler
+    {
+        // Overrides of the default builders as specified in code, this controls which map builder steps
+        // will be run when resource compiler is run for a map without specifiying any specific map builder
+        // steps. Additionally this controls which builders are displayed in the hammer build dialog.
+        DefaultMapBuilders
+        {
+            bakedlighting "1" // Enable lightmapping during compile time
+            envmap        "0" // turned off since it currently causes an assert and doesn't work due to some build issue
+            nav           "1" // Generate nav mesh data
+        }
 
-		SteamAudio
-		{
-			ReverbDefaults
-			{
-				GridSpacing			"3.0"
-				HeightAboveFloor	"1.5"
-				RebakeOption		"0"						// 0: cleanup, 1: manual, 2: auto
-				NumRays				"32768"
-				NumBounces			"64"
-				IRDuration			"1.0"
-				AmbisonicsOrder		"1"
-			}
-			PathingDefaults
-			{
-				GridSpacing			"3.0"
-				HeightAboveFloor	"1.5"
-				RebakeOption		"0"						// 0: cleanup, 1: manual, 2: auto
-				NumVisSamples		"1"
-				ProbeVisRadius		"0"
-				ProbeVisThreshold	"0.1"
-				ProbeVisPathRange	"1000.0"
-			}
-		}
-		SoundStackScripts
-		{
-			CompileStacksStrict "1"
-		}
-		VisBuilder
-		{
-			MaxVisClusters "4096"
-			PreMergeOpenSpaceDistanceThreshold "128.0"
-			PreMergeOpenSpaceMaxDimension "2048.0"
-			PreMergeOpenSpaceMaxRatio "8.0"
-			PreMergeSmallRegionsSizeThreshold "20.0"
-		}
+        MeshCompiler
+        {
+            OptimizeForMeshlets       "1"
+            TrianglesPerMeshlet       "64" // Maximum valid value currently is 126
+            UseMikkTSpace             "1"
+            EncodeVertexBuffer        "1"
+            EncodeVertexBufferVersion "1"
+            EncodeVertexBufferLevel   "3"
+            EncodeIndexBuffer         "1"
+            SplitDepthStream          "1"
+        }
 
-		VDataLocalization
-		{
-			GameOutputPath	"resource/localization/citadel_vdata"
-			TokenPrefix		"Citadel_VData_"
-		}
-		
-		TextureCompiler
-		{
-			//Compressor              "lz4"
-			//CompressMipsOnDisk      "1"
-			//CompressMinRatio        "95"
-			AllowNP2Textures		"1"
-			AllowPanoramaMipGeneration	"1"
-			//PublicToolsDefaultMaxRes "2048"
-		}
-	}
+        WorldRendererBuilder
+        {
+            VisibilityGuidedMeshClustering     "1"
+            MinimumTrianglesPerClusteredMesh   "8192"
+            MinimumVerticesPerClusteredMesh    "8192"
+            MinimumVolumePerClusteredMesh      "8192" // ~20x20x20 cube
+            MaxPrecomputedVisClusterMembership "96"
+            MaxCullingBoundsGroups             "128"
+            UseAggregateInstances              "1"
+            AggregateInstancingMeshlets        "1"
+            BakePropsWithExtraVertexStreams    "1"
+        }
 
-	Source1Import
-	{
-		// this is just copied from the left4dead3 gameinfo.gi
-		"forcevtxfileupconvert" 1
-	}
+        BakedLighting
+        {
+            Version                          "4"
+            ImportanceVolumeTransitionRegion "512" // distance we transition from high to low resolution charts
+            LightmapChannels
+            {
+                direct_light_shadows          "1"
+                debug_chart_color             "1"
+                directional_irradiance_sh2_dc "1"
 
-	WorldRenderer
-	{
-		EnvironmentMaps					1
-		EnvironmentMapFaceSize			256
-		EnvironmentMapRenderSize		1024
-		EnvironmentMapFormat			BC6H
-		EnvironmentMapPreviewFormat 		BC6H
-		EnvironmentMapColorSpace		linear
-		EnvironmentMapMipProcessor		GGXCubeMapBlur
-		// Build cubemaps into a cube array instead of individual cubemaps.
-		"EnvironmentMapUseCubeArray" 	1
-		"EnvironmentMapCacheSizeTools"  300
-		BindlessSceneObjectDesc			CitadelBindlessDesc
-		GrassCastsShadows				1
-	}
+                directional_irradiance_sh2_r
+                {
+                    CompressedFormat "DXT1"
+                }
 
-	SceneSystem
-	{
-		GpuLightBinner 1
-		FogCachedShadowAtlasWidth 2048
-		FogCachedShadowAtlasHeight 2048
-		FogCachedShadowTileSize 128
-		GpuLightBinnerSunLightFastPath 1
-		CSMCascadeResolution 2048
-		SunLightManagerCount 0
-		SunLightManagerCountTools 0
-		DefaultShadowTextureWidth 6144
-		DefaultShadowTextureHeight 6144
-		DynamicShadowResolution 1
+                directional_irradiance_sh2_g
+                {
+                    CompressedFormat "DXT1"
+                }
 
-		TransformTextureRowCount	1024
-		TransformTextureRowCountToolsMode 6144
-		SunLightMaxCascadeSize		4
-		SunLightShadowRenderMode	Depth
-		LayerBatchThresholdFullsort 20
-		NonTexturedGradientFog		1
-		// Temp till I can add support in citadel shaders
-		DisableLateAllocatedTransformBuffer 1
-		MinimumLateAllocatedVertexCacheBufferSizeMB 64
-		CubemapFog 1
-		VolumetricFog 1
-		FrameBufferCopyFormat R11G11B10F
-		Tonemapping 0
-		
-		WellKnownLightCookies
-		{
-			"blank" "materials/effects/lightcookies/blank.vtex"
-			"flashlight" "materials/effects/lightcookies/flashlight.vtex"
-		}
+                directional_irradiance_sh2_b
+                {
+                    CompressedFormat "DXT1"
+                }
+            }
+            LightmapGutterSize   "2" // For bicubic filtering
+            UseStaticLightProbes "0"
+            LPVAtlas             "1"
+            BC6HHueShiftFixup    "0" // Causes more artifacts than it solves atm
+            Repack2              "1"
+        }
 
-		ComputeShaderSkinning 1
-	}
+        SteamAudio
+        {
+            ReverbDefaults
+            {
+                GridSpacing      "3.0"
+                HeightAboveFloor "1.5"
+                RebakeOption     "0" // 0: cleanup, 1: manual, 2: auto
+                NumRays          "32768"
+                NumBounces       "64"
+                IRDuration       "1.0"
+                AmbisonicsOrder  "1"
+            }
+            PathingDefaults
+            {
+                GridSpacing       "3.0"
+                HeightAboveFloor  "1.5"
+                RebakeOption      "0" // 0: cleanup, 1: manual, 2: auto
+                NumVisSamples     "1"
+                ProbeVisRadius    "0"
+                ProbeVisThreshold "0.1"
+                ProbeVisPathRange "1000.0"
+            }
+        }
+        SoundStackScripts
+        {
+            CompileStacksStrict "1"
+        }
+        VisBuilder
+        {
+            MaxVisClusters                     "4096"
+            PreMergeOpenSpaceDistanceThreshold "128.0"
+            PreMergeOpenSpaceMaxDimension      "2048.0"
+            PreMergeOpenSpaceMaxRatio          "8.0"
+            PreMergeSmallRegionsSizeThreshold  "20.0"
+        }
 
-	NavSystem
-	{
-		"NavTileSize" "128.0"
-		"NavCellSize" "1.5"
-		"NavCellHeight" "2.0"
+        VDataLocalization
+        {
+            GameOutputPath "resource/localization/citadel_vdata"
+            TokenPrefix    "Citadel_VData_"
+        }
 
-		// Hull definitions live in scripts/nav_hulls.vdata
-		// Preset definitions live in scripts/nav_hulls_presets.vdata
-		"NavHullsPreset" "default"
+        TextureCompiler
+        {
+            // Compressor               "lz4"
+            // CompressMipsOnDisk       "1"
+            // CompressMinRatio         "95"
+            AllowNP2Textures            "1"
+            AllowPanoramaMipGeneration  "1"
+            // PublicToolsDefaultMaxRes "2048"
+        }
+    }
 
-		"NavRegionMinSize" "8"
-		"NavRegionMergeSize" "20"
-		"NavEdgeMaxLen" "1200"
-		"NavEdgeMaxError" "51.0"
-		"NavVertsPerPoly" "4"
-		"NavDetailSampleDistance" "120.0"
-		"NavDetailSampleMaxError" "2.0"
-		"NavSmallAreaOnEdgeRemovalSize" "81.0"
-	}
+    Source1Import
+    {
+        // this is just copied from the left4dead3 gameinfo.gi
+        forcevtxfileupconvert "1"
+    }
 
-	AnimationSystem
-	{
-		"DisableServerInterpCompensation"	"1"
-		"DisableAnimationScript" 	"1"
-		"ServerPoseRecipeHistorySize"	"60"
-		"ClientPoseRecipeHistorySize"	"60"
+    WorldRenderer
+    {
+        EnvironmentMaps             "1"
+        EnvironmentMapFaceSize      "256"
+        EnvironmentMapRenderSize    "1024"
+        EnvironmentMapFormat        "BC6H"
+        EnvironmentMapPreviewFormat "BC6H"
+        EnvironmentMapColorSpace    "linear"
+        EnvironmentMapMipProcessor  "GGXCubeMapBlur"
+        // Build cubemaps into a cube array instead of individual cubemaps.
+        EnvironmentMapUseCubeArray   "1"
+        EnvironmentMapCacheSizeTools "300"
+        BindlessSceneObjectDesc      "CitadelBindlessDesc"
+        GrassCastsShadows            "1"
+    }
 
-	}
+    SceneSystem
+    {
+        GpuLightBinner                 "1"
+        FogCachedShadowAtlasWidth      "2048"
+        FogCachedShadowAtlasHeight     "2048"
+        FogCachedShadowTileSize        "128"
+        GpuLightBinnerSunLightFastPath "1"
+        CSMCascadeResolution           "2048"
+        SunLightManagerCount           "0"
+        SunLightManagerCountTools      "0"
+        DefaultShadowTextureWidth      "6144"
+        DefaultShadowTextureHeight     "6144"
+        DynamicShadowResolution        "1"
 
-	ModelDoc
-	{
-		"models_gamedata"			"models_gamedata.fgd"
-		"features"					"animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
-	}
+        TransformTextureRowCount          "1024"
+        TransformTextureRowCountToolsMode "6144"
+        SunLightMaxCascadeSize            "4"
+        SunLightShadowRenderMode          "Depth"
+        LayerBatchThresholdFullsort       "20"
+        NonTexturedGradientFog            "1"
+        // Temp till I can add support in citadel shaders
+        DisableLateAllocatedTransformBuffer         "1"
+        MinimumLateAllocatedVertexCacheBufferSizeMB "64"
+        CubemapFog                                  "1"
+        VolumetricFog                               "1"
+        FrameBufferCopyFormat                       "R11G11B10F"
+        Tonemapping                                 "0"
 
-	Particles
-	{
-		"EnableParticleShaderFeatureBranching"	"1"
-		"Float16HDRBackBuffer" "1"
-		"PET_SupportFadingOpaqueModels" "1"
-		"Features" "non_homogenous_forward_layer_only"
-	}
+        WellKnownLightCookies
+        {
+            blank      "materials/effects/lightcookies/blank.vtex"
+            flashlight "materials/effects/lightcookies/flashlight.vtex"
+        }
 
-	ConVars
-	{	 
-		"rate"
-		{
-			"min"		"98304"
-			"default"	"786432"
-			"max"		"1000000"
-		}
-		"sv_minrate"	"98304"
-		"sv_maxunlag"	"0.500"
-		"sv_maxunlag_player" "0.200"
-		"sv_lagcomp_filterbyviewangle" "false"
+        ComputeShaderSkinning "1"
+    }
 
-		// Spew warning when adding/removing classes to/from the top of the hierarchy
-		"panorama_classes_perf_warning_threshold_ms" "0.75"
+    NavSystem
+    {
+        NavTileSize   "128.0"
+        NavCellSize   "1.5"
+        NavCellHeight "2.0"
 
-		// Panorama - enable minidumps on JS exceptions
-		"panorama_js_minidumps" "1"
-		// Enable the render target cache optimization.
-		"panorama_disable_render_target_cache" "0"
+        // Hull definitions live in scripts/nav_hulls.vdata
+        // Preset definitions live in scripts/nav_hulls_presets.vdata
+        NavHullsPreset "default"
 
-		// Enable the composition layer optimization
-		"panorama_skip_composition_layer_content_paint" "1"
+        NavRegionMinSize              "8"
+        NavRegionMergeSize            "20"
+        NavEdgeMaxLen                 "1200"
+        NavEdgeMaxError               "51.0"
+        NavVertsPerPoly               "4"
+        NavDetailSampleDistance       "120.0"
+        NavDetailSampleMaxError       "2.0"
+        NavSmallAreaOnEdgeRemovalSize "81.0"
+    }
 
-		// too expensive (500MB+) to load this
-		"snd_steamaudio_load_reverb_data" "0"
-		"snd_steamaudio_load_pathing_data" "0"
+    AnimationSystem
+    {
+        DisableServerInterpCompensation "1"
+        DisableAnimationScript          "1"
+        ServerPoseRecipeHistorySize     "60"
+        ClientPoseRecipeHistorySize     "60"
 
-		// Steam Audio project specific convars
-		"snd_steamaudio_enable_custom_hrtf"		"0"
-		"snd_steamaudio_active_hrtf"			"0"
-		"snd_steamaudio_reverb_update_rate"		"10.0"
-		"snd_steamaudio_ir_duration"			"1.0"
-		"snd_steamaudio_enable_pathing"			"0"
-		"snd_steamaudio_invalid_path_length"	"0.0"
-		"cl_disconnect_soundevent"				"citadel.convar.stop_all_game_layer_soundevents"
-		"snd_event_browser_default_stack"		"citadel_default_3d"
-		
-		// voip
-		"voice_in_process"			            "1"
+    }
 
-		// Sound debugging
-		"snd_report_audio_nan" "1"
+    ModelDoc
+    {
+        models_gamedata "models_gamedata.fgd"
+        features        "animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
+    }
 
-		// Audio system settings
-		"snd_sos_max_event_base_depth" "10"
-		"sos_use_guid_filter" "1"
+    Particles
+    {
+        EnableParticleShaderFeatureBranching "1"
+        Float16HDRBackBuffer                 "1"
+        PET_SupportFadingOpaqueModels        "1"
+        Features                             "non_homogenous_forward_layer_only"
+    }
 
-		"voice_always_sample_mic"               
-		{
-			"version"	"2"
-			"default"	"0"
-		}
+    ConVars
+    {
+        rate
+        {
+            min     "98304"
+            default "786432"
+            max     "1000000"
+        }
+        sv_minrate                   "98304"
+        sv_maxunlag                  "0.500"
+        sv_maxunlag_player           "0.200"
+        sv_lagcomp_filterbyviewangle "false"
 
-		"reset_voice_on_input_stallout"         "0"
-		"voice_input_stallout"                  "0.5"
-		"cl_usesocketsforloopback" "1"
-		"cl_poll_network_early" "0"
+        // Spew warning when adding/removing classes to/from the top of the hierarchy
+        panorama_classes_perf_warning_threshold_ms "0.75"
 
-		// Perf/Parallelism
-		"iv_parallel_restore" "1"
+        // Panorama - enable minidumps on JS exceptions
+        panorama_js_minidumps "1"
+        // Enable the render target cache optimization.
+        panorama_disable_render_target_cache "0"
 
-		// For perf reasons, since we don't use source-based DSP:
-		"disable_source_soundscape_trace"       "1"
-		
-		// Networking - Induced latency (pred offset)
-		"cl_tickpacket_recvmargin_desired" "5" 					// 5 ms base, min. floor for protecting against thrashing the queue
-		"cl_tickpacket_desired_queuelength" "0"					// 0 = attempt to always reach the queue's min floor
-		"cl_async_usercmd_send_disabled_recvmargin_min" "0.5"	// Additional frame since we do not use the async usercmd send (potentially unneccessary)
-		"cl_clock_buffer_ticks"	"1"
-		"cl_interp_ratio" "0"
-		"cl_async_usercmd_send" "false"
+        // Enable the composition layer optimization
+        panorama_skip_composition_layer_content_paint "1"
 
-		"fps_max"		"400"
-		"fps_max_ui"	"120"
+        // too expensive (500MB+) to load this
+        snd_steamaudio_load_reverb_data  "0"
+        snd_steamaudio_load_pathing_data "0"
 
-		"in_button_double_press_window" "0.3"
+        // Steam Audio project specific convars
+        snd_steamaudio_enable_custom_hrtf  "0"
+        snd_steamaudio_active_hrtf         "0"
+        snd_steamaudio_reverb_update_rate  "10.0"
+        snd_steamaudio_ir_duration         "1.0"
+        snd_steamaudio_enable_pathing      "0"
+        snd_steamaudio_invalid_path_length "0.0"
+        cl_disconnect_soundevent           "citadel.convar.stop_all_game_layer_soundevents"
+        snd_event_browser_default_stack    "citadel_default_3d"
 
-		// Convars that control spatialization of UI audio.
-		"snd_ui_positional"								"1"
-		"snd_ui_spatialization_spread"					"2.4"
-		
-		// sound volume rate change limiting
-		"snd_envelope_rate"								"100.0"
-		"snd_soundmixer_update_maximum_frame_rate" 		"0"
+        // voip
+        voice_in_process "1"
 
-		//don't let people mess with speaker config settings.
-		"speaker_config"
-		{
-			"min"		"0"
-			"default"	"0"
-			"max"		"2"
-		}
+        // Sound debugging
+        snd_report_audio_nan "1"
 
-		"cq_buffer_bloat_msecs_max" "120"
+        // Audio system settings
+        snd_sos_max_event_base_depth "10"
+        sos_use_guid_filter          "1"
 
-		"snd_soundmixer"						"Default_Mix"
-		"cloth_filter_transform_stateless" "0"
+        voice_always_sample_mic
+        {
+            version "2"
+            default "0"
+        }
 
-		"cl_joystick_enabled" "0"
-		"panorama_joystick_enabled" "0"
+        reset_voice_on_input_stallout "0"
+        voice_input_stallout          "0.5"
+        cl_usesocketsforloopback      "1"
+        cl_poll_network_early         "0"
 
-		"snd_event_browser_focus_events" "true"
+        // Perf/Parallelism
+        iv_parallel_restore "1"
 
-		"cl_max_particle_pvs_aabb_edge_length" "100"
-		
-		// Allow aggregation of particles (for perf)
-		"cl_aggregate_particles" "true"
-		
-		"citadel_enable_vdata_sound_preload" "true"
-		"r_add_views_in_pre_output"		"1"
+        // For perf reasons, since we don't use source-based DSP:
+        disable_source_soundscape_trace "1"
 
-	}
+        // Networking - Induced latency (pred offset)
+        cl_tickpacket_recvmargin_desired              "5"   // 5 ms base, min. floor for protecting against thrashing the queue
+        cl_tickpacket_desired_queuelength             "0"   // 0 = attempt to always reach the queue's min floor
+        cl_async_usercmd_send_disabled_recvmargin_min "0.5" // Additional frame since we do not use the async usercmd send (potentially unneccessary)
+        cl_clock_buffer_ticks                         "1"
+        cl_interp_ratio                               "0"
+        cl_async_usercmd_send                         "false"
 
-	Memory
-	{
-		"EstimatedMaxCPUMemUsageMB"	"1"
-		"EstimatedMinGPUMemUsageMB"	"1"
+        fps_max    "400"
+        fps_max_ui "120"
 
-		"ShowInsufficientPageFileMessageBox" "1"
-		"ShowLowAvailableVirtualMemoryMessageBox" "1"
-	}
+        in_button_double_press_window "0.3"
+
+        // Convars that control spatialization of UI audio.
+        snd_ui_positional            "1"
+        snd_ui_spatialization_spread "2.4"
+
+        // sound volume rate change limiting
+        snd_envelope_rate                        "100.0"
+        snd_soundmixer_update_maximum_frame_rate "0"
+
+        //don't let people mess with speaker config settings.
+        speaker_config
+        {
+            min     "0"
+            default "0"
+            max     "2"
+        }
+
+        cq_buffer_bloat_msecs_max "120"
+
+        snd_soundmixer                   "Default_Mix"
+        cloth_filter_transform_stateless "0"
+
+        cl_joystick_enabled       "0"
+        panorama_joystick_enabled "0"
+
+        snd_event_browser_focus_events "true"
+
+        cl_max_particle_pvs_aabb_edge_length "100"
+
+        // Allow aggregation of particles (for perf)
+        cl_aggregate_particles "true"
+
+        citadel_enable_vdata_sound_preload "true"
+        r_add_views_in_pre_output          "1"
+
+    }
+
+    Memory
+    {
+        EstimatedMaxCPUMemUsageMB "1"
+        EstimatedMinGPUMemUsageMB "1"
+
+        ShowInsufficientPageFileMessageBox      "1"
+        ShowLowAvailableVirtualMemoryMessageBox "1"
+    }
 }
-

--- a/kaizuchaneru's minimum spec/gameinfo.gi
+++ b/kaizuchaneru's minimum spec/gameinfo.gi
@@ -4,1106 +4,1106 @@
 // Their twitch can be found here! Give them a follow
 // https://www.twitch.tv/kaizuchaneru
 
-"GameInfo"
+GameInfo
 {
-	game 		"citadel"
-	title 		"Citadel"
-	type		multiplayer_only
-	nomodels 1
-	nohimodel 1
-	nocrosshair 0
-	hidden_maps
-	{
-		"test_speakers"			1
-		"test_hardware"			1
-	}
-	nodegraph 0
-	perfwizard 0
-	tonemapping 0
-	GameData	"citadel.fgd"
-
-	DisallowGameInfoConditionals 1
-	PGIVersion "6E09D3ED5A47F6A97443813F0E00F90BAA435918F82DF0C9B5DA46D27A33D903"
-
-	Localize
-	{
-		DuplicateTokensAssert	1
-		DisallowTokenContexts	1
-	}
-
-	SupportedLanguages
-	{
-		"brazilian" "3"
-		"czech" "3"
-		"english" "3"
-		"french" "3"
-		"german" "3"
-		"italian" "3"
-		"indonesian" "3"
-		"japanese" "3"
-		"koreana" "3"
-		"latam" "3"
-		"polish" "3"
-		"russian" "3"
-		"schinese" "3"
-		"spanish" "3"
-		"thai" "3"
-		"turkish" "3"
-		"ukrainian" "3"
-	}
-	
-	FileSystem
-	{	
-		//
-		// The code that loads this file automatically does a few things here:
-		//
-		// 1. For each "Game" search path, it adds a "GameBin" path, in <dir>\bin
-		// 2. For each "Game" search path, it adds another "Game" path in front of it with _<language> at the end.
-		//    For example: c:\hl2\cstrike on a french machine would get a c:\hl2\cstrike_french path added to it.
-		// 3. If no "Mod" key, for the first "Game" search path, it adds a search path called "MOD".
-		// 4. If no "Write" key, for the first "Game" search path, it adds a search path called "DEFAULT_WRITE_PATH".
-		//
-
-		//
-		// Search paths are relative to the exe directory\..\
-		//
-		SearchPaths
-		{
-			// These are optional language paths. They must be mounted first, which is why there are first in the list.
-			// *LANGUAGE* will be replaced with the actual language name. If not running a specific language, these paths will not be mounted
-			Game_Language		citadel_*LANGUAGE*
-
-			// These are optional low-violence paths. They will only get mounted if you're in a low-violence mode.
-			Game_LowViolence	citadel_lv
-			Game                		citadel/addons
-			Mod                 		citadel
-          		Write               		citadel          
-			Game				citadel
-			Game				core
-		}
-	}
-	
-	MaterialSystem2
-	{
-		RenderModes
-		{
-			game Default
-			game Forward
-			game Deferred
-			game Outline
-			game Depth
-			game FrontDepth
-
-			dev ToolsVis // Visualization modes for all shaders (lighting only, normal maps only, etc.)
-			dev ToolsWireframe // This should use the ToolsVis mode above instead of being its own mode\
-
-			tools ToolsUtil // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
-		}
-	}
-
-	MaterialEditor
-	{
-		"DefaultShader" "environment_texture_set"
-	}
-
-	NetworkSystem
-	{
-		BetaUniverse
-		{
-			FakeLag			40
-			FakeLoss		.1
-			//FakeReorderPct 0.05
-			//FakeReorderDelay 10
-			//FakeJitter "low"
-			// Turning off fake jitter for now while I work on making the CQ totally solid
-			FakeReorderPct 0
-			FakeReorderDelay 0
-			FakeJitter "off"
-		}
-
-		"SkipRedundantChangeCallbacks"	"1"
-	}
-
-	RenderSystem
-	{
-		IndexBufferPoolSizeMB 32
-		UseReverseDepth 1
-		Use32BitDepthBuffer 0
-		Use32BitDepthBufferWithoutStencil 0
-		SwapChainSampleableDepth 1
-		VulkanMutableSwapchain 1
-		"LowLatency"								"1"
-		"VulkanOnly_Linux"							"1"
-		"VulkanRequireSubgroupWaveOpSupport"		"1"
-		"VulkanRequireDescriptorIndexing"			"1"
-		"VulkanSteamShaderCache" "1"
-		"VulkanSteamAppShaderCache" "1"
-		"VulkanSteamDownloadedShaderCache" "1"
-		"VulkanAdditionalShaderCache" "vulkan_shader_cache.foz"
-		"VulkanStagingPMBSizeLimitMB" "384"
-		"GraphicsPipelineLibrary"	"1"
-		"VulkanOnlyTestProbability" "0"
-		"VulkanDefrag"				"1"
-		"MinStreamingPoolSizeMB"	"1024"
-		"MinStreamingPoolSizeMBTools" "2048"
-	}
-
-	NVNGX
-	{
-		AppID 103371621
-		SupportsDLSS 1
-	}
-
-	Engine2
-	{
-		HasModAppSystems 1
-		Capable64Bit 1
-		URLName citadel
-		RenderingPipeline
-		{
-			SupportsMSAA 0
-			DistanceField 1
-		}
-		PauseSinglePlayerOnGameOverlay 1
-		DefensiveConCommands 1
-		DisableLoadingPlaque 1
-	}
-
-	ContentBuilder
-	{
-		ResourceCompilerDirectXUsesWARP "0"
-	}
-
-	SoundSystem
-	{
-		SteamAudioEnabled            "1"
-		WaveDataCacheSizeMB          "256"
-		"UsePlatTime"            "1"
-	}
-	Sounds
-	{
-		HierarchicalEncodingFiles	 "1"
-	}
-
-	ToolsEnvironment
-	{
-		"Engine"	"Source 2"
-		"ToolsDir"	"../sdktools"	// NOTE: Default Tools path. This is relative to the mod path.
-	}
-	
-	pulse
-	{
-		"pulse_enabled"					"1"
-	}
-
-	Hammer
-	{
-		"fgd"					"citadel.fgd"	// NOTE: This is relative to the 'game' path.
-		"GameFeatureSet"		"Citadel"
-		"DefaultSolidEntity"	"trigger_multiple"
-		"DefaultPointEntity"	"info_player_start"
-		"NavMarkupEntity"		"func_nav_markup"
-		"OverlayBoxSize"			"8"
-		"TileMeshesEnabled"			"1"
-		"RenderMode"				"ToolsVis"
-		"CreateRenderClusters"		"1"
-		"DefaultMinDrawVolumeSize"	"2048"
-		"DefaultMinTrianglesPerCluster"	"16384"
-		"TileGridSupportsBlendHeight"	"1"
-		"TileGridBlendDefaultColor"	"0 255 0"
-		"LoadScriptEntities" "0"
-		"UsesBakedLighting" "1"
-		"UseAnalyticGrid" "0"
-		"SupportsDisplacementMapping" "0"
-		"SteamAudioEnabled"				"1"
-		"LatticeDeformerEnabled"		"1"
-		"ShadowAtlasWidth" "16384"
-		"ShadowAtlasHeight" "16384"
-		"TimeSlicedShadowMapRendering" "1"
-	}
-
-	SoundTool
-	{
-		"DefaultSoundEventType" "src1_3d"
-
-		SoundEventBaseOptions
-		{
-			"Base.Announcer.VO.2d" ""
-			"Base.World.VO.Emitter.3d" ""
-			"Base.Hero.VO.Ping.2d" ""
-			"Base.Hero.VO.2d" ""
-			"Base.Hero.VO.3d" ""
-			"Base.Hero.VO.Ability.3d" ""
-			"Base.Hero.VO.Ultimate.3d" ""
-			"Base.Hero.VO.Dash.3d" ""
-			"Base.Hero.VO.Effort.3d" ""
-			"Base.Hero.VO.Pain.3d" ""
-			"Base.Hero.VO.Melee.3d" ""
-			"Base.Hero.VO.Death.3d" ""
-		}
-	}
-
-	RenderPipelineAliases
-	{
-	}
-
-	ResourceCompiler
-	{
-		// Overrides of the default builders as specified in code, this controls which map builder steps
-		// will be run when resource compiler is run for a map without specifiying any specific map builder
-		// steps. Additionally this controls which builders are displayed in the hammer build dialog.
-		DefaultMapBuilders
-		{
-			"bakedlighting"	"1"	// Enable lightmapping during compile time		
-			"envmap"	"0" // turned off since it currently causes an assert and doesn't work due to some build issue
-			"nav"		"1"	// Generate nav mesh data
-		}
-
-		MeshCompiler
-		{
-			OptimizeForMeshlets 1
-			TrianglesPerMeshlet 64	// Maximum valid value currently is 126
-			UseMikkTSpace 1
-			EncodeVertexBuffer 1
-            EncodeVertexBufferVersion 1
-            EncodeVertexBufferLevel 3
-			EncodeIndexBuffer 1
-			SplitDepthStream 1
-		}
-
-		WorldRendererBuilder
-		{
-			VisibilityGuidedMeshClustering      "1"
-			MinimumTrianglesPerClusteredMesh    "8192"
-			MinimumVerticesPerClusteredMesh     "8192"
-			MinimumVolumePerClusteredMesh       "8192"       // ~20x20x20 cube
-			MaxPrecomputedVisClusterMembership  "96"
-			MaxCullingBoundsGroups              "128"
-			UseAggregateInstances				"1"
-			AggregateInstancingMeshlets			"1"
-			BakePropsWithExtraVertexStreams		"1"
-		}
-
-		BakedLighting
-		{
-			Version 4
-			ImportanceVolumeTransitionRegion 512            // distance we transition from high to low resolution charts 
-			LightmapChannels
-			{
-				direct_light_shadows 1
-				debug_chart_color 1
-				directional_irradiance_sh2_dc 1
-				
-				directional_irradiance_sh2_r
-				{
-					CompressedFormat DXT1
-				}
-				
-				directional_irradiance_sh2_g
-				{
-					CompressedFormat DXT1
-				}
-				
-				directional_irradiance_sh2_b
-				{
-					CompressedFormat DXT1
-				}
-			}
-			LightmapGutterSize 2 // For bicubic filtering
-			UseStaticLightProbes 0
-			LPVAtlas 1
-			BC6HHueShiftFixup 0 // Causes more artifacts than it solves atm
-			Repack2 1
-		}
-
-		SteamAudio
-		{
-			ReverbDefaults
-			{
-				GridSpacing			"3.0"
-				HeightAboveFloor	"1.5"
-				RebakeOption		"0"						// 0: cleanup, 1: manual, 2: auto
-				NumRays				"32768"
-				NumBounces			"64"
-				IRDuration			"1.0"
-				AmbisonicsOrder		"1"
-			}
-			PathingDefaults
-			{
-				GridSpacing			"3.0"
-				HeightAboveFloor	"1.5"
-				RebakeOption		"0"						// 0: cleanup, 1: manual, 2: auto
-				NumVisSamples		"1"
-				ProbeVisRadius		"0"
-				ProbeVisThreshold	"0.1"
-				ProbeVisPathRange	"1000.0"
-			}
-		}
-		SoundStackScripts
-		{
-			CompileStacksStrict "1"
-		}
-		VisBuilder
-		{
-			MaxVisClusters "4096"
-			PreMergeOpenSpaceDistanceThreshold "128.0"
-			PreMergeOpenSpaceMaxDimension "2048.0"
-			PreMergeOpenSpaceMaxRatio "8.0"
-			PreMergeSmallRegionsSizeThreshold "20.0"
-		}
-
-		VDataLocalization
-		{
-			GameOutputPath	"resource/localization/citadel_vdata"
-			TokenPrefix		"Citadel_VData_"
-		}
-		
-		TextureCompiler
-		{
-			//Compressor              "lz4"
-			//CompressMipsOnDisk      "1"
-			//CompressMinRatio        "95"
-			AllowNP2Textures		"1"
-			AllowPanoramaMipGeneration	"1"
-			//PublicToolsDefaultMaxRes "2048"
-		}
-	}
-
-	Source1Import
-	{
-		// this is just copied from the left4dead3 gameinfo.gi
-		"forcevtxfileupconvert" 1
-	}
-
-	WorldRenderer
-	{
-		EnvironmentMaps					1
-		EnvironmentMapFaceSize			256
-		EnvironmentMapRenderSize		1024
-		EnvironmentMapFormat			BC6H
-		EnvironmentMapPreviewFormat 		BC6H
-		EnvironmentMapColorSpace		linear
-		EnvironmentMapMipProcessor		GGXCubeMapBlur
-		// Build cubemaps into a cube array instead of individual cubemaps.
-		"EnvironmentMapUseCubeArray" 	1
-		"EnvironmentMapCacheSizeTools"  300
-		BindlessSceneObjectDesc			CitadelBindlessDesc
-		GrassCastsShadows				1
-	}
-
-	SceneSystem
-	{
-		GpuLightBinner 1
-		FogCachedShadowAtlasWidth 0
-		FogCachedShadowAtlasHeight 0
-		FogCachedShadowTileSize 0
-		GpuLightBinnerSunLightFastPath 1
-		CSMCascadeResolution 0
-		SunLightManagerCount 0
-		SunLightManagerCountTools 0
-		DefaultShadowTextureWidth 0
-		DefaultShadowTextureHeight 0
-		DynamicShadowResolution 0
-
-		TransformTextureRowCount	1024
-		TransformTextureRowCountToolsMode 6144
-		SunLightMaxCascadeSize		4
-		SunLightShadowRenderMode	Depth
-		LayerBatchThresholdFullsort 20
-		NonTexturedGradientFog		0
-		// Temp till I can add support in citadel shaders
-		DisableLateAllocatedTransformBuffer 1
-		MinimumLateAllocatedVertexCacheBufferSizeMB 64
-		CubemapFog 0
-		VolumetricFog 0
-		FrameBufferCopyFormat R11G11B10F
-		Tonemapping 0
-		
-		WellKnownLightCookies
-		{
-			"blank" "materials/effects/lightcookies/blank.vtex"
-			"flashlight" "materials/effects/lightcookies/flashlight.vtex"
-		}
-
-		ComputeShaderSkinning 1
-	}
-
-	NavSystem
-	{
-		"NavTileSize" "128.0"
-		"NavCellSize" "1.5"
-		"NavCellHeight" "2.0"
-
-		// Hull definitions live in scripts/nav_hulls.vdata
-		// Preset definitions live in scripts/nav_hulls_presets.vdata
-		"NavHullsPreset" "default"
-
-		"NavRegionMinSize" "8"
-		"NavRegionMergeSize" "20"
-		"NavEdgeMaxLen" "1200"
-		"NavEdgeMaxError" "51.0"
-		"NavVertsPerPoly" "4"
-		"NavDetailSampleDistance" "120.0"
-		"NavDetailSampleMaxError" "2.0"
-		"NavSmallAreaOnEdgeRemovalSize" "81.0"
-	}
-
-	AnimationSystem
-	{
-		"DisableServerInterpCompensation"	"1"
-		"DisableAnimationScript" 	"1"
-		"ServerPoseRecipeHistorySize"	"60"
-		"ClientPoseRecipeHistorySize"	"60"
-
-	}
-
-	ModelDoc
-	{
-		"models_gamedata"			"models_gamedata.fgd"
-		"features"					"animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
-	}
-
-	Particles
-	{
-		"EnableParticleShaderFeatureBranching"	"1"
-		"Float16HDRBackBuffer" "1"
-		"PET_SupportFadingOpaqueModels" "1"
-		"Features" "non_homogenous_forward_layer_only"
-	}
-
-	ConVars
-	{	
-// ================ CORE QUALITY ================
-"gpu_level" "1"                     // Minimum Shader Details Level 0= high
-"cpu_level" "1"                     // Minimum Effect Details Level
-"mat_set_shader_quality" "0"
-
-// ================ FOV ================
-"r_aspectratio" "2.3"              // [ADJUST] FOV control: 1.33=70fov | 1.56=75fov | 1.75=80fov | 2.0=85fov | 2.15=90fov | 2.49=100fov | 3.0=110fov | 3.5=120fov
-
-// ================ LIGHTING & SHADOWS ================
-"r_directlighting" "false"
-"r_ssao" "false"                        // Disable ambient occlusion
-"r_shadows" "0"                     // [FPS IMPACT] 0=Off (max FPS) | 1=On (shadows enabled)
-"r_rendersun" "0"
-"lb_enable_shadow_casting" "0"      // [FPS IMPACT] 0=Off (shadows disabled, +FPS) | 1=On (shadow casting enabled)
-"lb_csm_draw_alpha_tested" "0"
-"lb_csm_draw_translucent" "0"
-"lb_barnlight_shadowmap_scale" "0.01" //default 0.5
-"lb_csm_cascade_size_override" "0.25" //was 1
-"lb_dynamic_shadow_resolution_quantization" "32" //64
-"lb_csm_override_staticgeo_cascades_value" "0"
-"lb_csm_receiver_plane_depth_bias" "0.00002"
-"lb_csm_receiver_plane_depth_bias_transmissive_backface" "0.0002"
-"lb_sun_csm_size_cull_threshold_texels" "30"
-"lb_dynamic_shadow_resolution_base" "32"
-"lb_enable_fog_mixed_shadows" "0"
-"r_citadel_sun_shadow_slope_scale_depth_bias" "1.0" //was 1
-"r_lightmap_size_directional_irradiance" "0" //was 4
-"r_size_cull_threshold_shadow" "200" //Default: 100<br>Threshold of shadow map size percentage below which objects get culled
-"csm_max_shadow_dist_override" "1500"
-"sc_cache_envmap_lpv_lookup" "false" //was true
-"cl_retire_low_priority_lights" "1"
-"sc_disable_spotlight_shadows" "1"
-"sc_disable_shadow_materials" "1"
-"cl_globallight_shadow_mode" "0"
-"lb_enable_dynamic_lights" "0"
-"lb_enable_lights" "0" //was 1
-"lb_enable_stationary_lights" "0"         // Disable stationary lights
-"lb_max_visible_barn_lights_override" "1"
-//"lb_max_visible_envmaps_override" "4" //default 4 DO NOT CHANGE OR IT BREAKS GAME
-"lb_ssss_samples" "0"
-//"r_multiscattering" "0"                   // Disable multiscattering (only works with shadows disable)
-
-// ================ SPARSE SHADOW TREE ================
-"sparseshadowtree_enable_rendering" "0"
-"sparseshadowtree_disable_for_viewmodel" "1"
-
-
-// ================ DISTANCE FIELD ================
-"r_citadel_distancefield_farfield_enable" "false"
-"r_citadel_npr_outlines_max_dist" "600"
-
-// ================ FOG & ATMOSPHERE ================
-"r_enable_volume_fog" "0"
-"r_enable_gradient_fog" "0"
-"r_enable_cubemap_fog" "0"
-"volume_fog_intermediate_textures_hdr" "0"
-
-// ================ SKY & ENVIRONMENT ================
-"r_draw3dskybox" "0"
-"r_drawskybox" "0"                  // Set to 0 to disable skybox
-"r_monitor_3dskybox" "0"
-"r_world_wind_strength" "0"
-
-// ================ SSAO ================
-"r_citadel_ssao_bent_normals" "false"
-"r_citadel_ssao_denoise_passes" "0"
-"r_citadel_ssao_quality" "0"
-"r_citadel_ssao_radius" "0"
-"r_citadel_ssao_thin_occluder_compensation" "0"
-
-// ================ PARTICLE SYSTEM ================
-"r_particle_max_detail_level" "0 "//was 0
-"r_particle_cables_cast_shadows" "0"
-"r_RainParticleDensity" "0"
-"r_physics_particle_op_spawn_scale" "0"
-"r_particle_max_size_cull" "1200" //was 800 Particle systems larger than this in every dimension skip culling to save CPU.  They will be drawn anyway
-"particle_cluster_nodraw" "1"
-"r_particle_mixed_resolution_viewstart" "800"
-"r_particle_max_draw_distance" "300000" // Lower = less particle range, more FPS, dont go below this value it doesnt draw trooper hp bar,
-"r_particle_model_new8" "0"
-"cl_show_splashes" "0"
-"r_particle_skip_postsim" "1"
-"r_limit_particle_job_duration" "1"
-"cl_particle_sim_fallback_threshold_ms" "0" // [ADJUST] Lower = more aggressive fallback to simple particles (higher FPS, less detail)
-"cl_particle_fallback_base" "10"
-"cl_particle_fallback_multiplier" "10" //was 10
-"cl_particle_sim_fallback_base_multiplier" "100" //default 10
-"r_particle_min_timestep" "0.001"
-
-// ================ PHYSICS & CLOTH ================
-"cloth_update" "1"                   // [FPS IMPACT] 0=Off (cosmetic only, +FPS) | 1=On (cloth physics enabled)
-"cloth_sim_on_tick" "0"
-"presettle_cloth_iterations" "0" //default 3
-"pred_cloth_pos_max" "0"           // Reduce cloth prediction was 1
-"pred_cloth_pos_multiplier" "0" //was 0.3
-"pred_cloth_pos_strength" "0" //was 0.1
-"pred_cloth_rot_high" "0" //was 0.05
-"pred_cloth_rot_low" "0" //was 0.005
-"pred_cloth_rot_multiplier" "0" //was 0.2 changing these values does fucking nothing
-"cl_phys_timescale" "1"              // [FPS IMPACT] 0=Disable physics (max FPS) | 1=Normal physics | Lower = slower physics, less CPU
-"cl_fasttempentcollision" "999999" //test Temp Entities" are things like shell casings hitting the floor. Increasing this number usually tells the engine to skip collision checks for them entirely or expire them instantly to avoid physics costs.
-
-"phys_threaded_cloth_bone_update" "1"
-"phys_threaded_kinematic_bone_update" "1"
-"phys_threaded_transform_update" "1"
-
-// ================ RAGDOLL ================
-"cl_ragdoll_limit" "0"              // Set it on console if ragdoll still lingers longer
-"ragdoll_parallel_pose_control" "1"
-
-// ================ MODEL & DECAL OPTIMIZATIONS ================
-"r_drawmodeldecals" "0" //does not exist in master convar
-"r_character_decal_resolution" "0.01" //default 1
-"r_decals" "1"                  // im p sure valve killed this command [ADJUST] Max decals visible: 1= only 1 bullet hole(max FPS) | 16=default
-"r_propsmaxdist" "600"
-"props_break_max_pieces_perframe" "1"  //was 2
-"r_citadel_screenspace_particles_full_res" "0"
-"r_citadel_gpu_culling_shadows" "1"
-"skeleton_instance_lod_optimization" "1"
-"r_size_cull_threshold" "1.2" // do not go over or youll have wall hack
-"r_hair_ao" "0"
-"r_render_hair" "0"                   // doesnt work [FPS IMPACT] 0=Off (max FPS boost, bald heroes) | 1=On (hair rendered)
-"r_haircull_percent" "100"
-"ik_final_fixup_enable" "0"
-"ik_fabrik_align_chain" "0"
-"cl_impacteffects" "0"
-"enable_boneflex" "false"            // cloth flexing
-"cl_eye_yaw_multiplier" "0"
-
-// ================ LOD & CULLING ================
-"sc_instanced_mesh_lod_bias" "15"     // [FPS IMPACT] Higher = lower quality models, more FPS | 0=High quality | 10=Low quality
-"sc_instanced_mesh_lod_bias_shadow" "10" // Bias for LOD selection of instanced meshes in shadowmaps
-"sc_instanced_mesh_motion_vectors" "0" // Set 1 if you use motion blur
-"sc_instanced_mesh_size_cull_bias" "10" // Bias for size culling of instanced meshes
-"sc_instanced_mesh_size_cull_bias_shadow" "10" // Bias for size culling instanced meshes in shadowmaps
-"sc_fade_distance_scale_override" "180"
-"sc_clutter_enable" "false"                   // [FPS IMPACT] 0=No debris/props (max FPS) | 1=Props visible (immersive)
-"sc_aggregate_bvh_threshold" "16"         // Lower BVH threshold (default: 128)
-"sc_layer_batch_threshold" "16"           // Lower batch threshold (default: 128)
-"sc_layer_batch_threshold_fullsort" "20" //default 80
-
-// ================ ROPE PHYSICS ================
-"rope_collide" "0"
-"rope_subdiv" "0"
-"rope_wind_dist" "0"
-"rope_smooth_enlarge" "0"
-"rope_smooth_maxalpha" "0"
-"rope_smooth_maxalphawidth" "0"
-"rope_smooth_minalpha" "0"
-"rope_smooth_minwidth" "0"
-"r_ropetranslucent" "0"
-"r_drawropes" "0"
-
-// ================ TERRAIN & FOLIAGE ================
-"r_grass_quality" "0"
-"r_grass_start_fade" "0"
-"r_grass_end_fade" "0"
-
-// ================ UI & HUD ================
-"panorama_disable_box_shadow" "1"
-"r_dashboard_render_quality" "0"
-"closecaption" "false"
-"citadel_hud_objective_health_enabled" "2"  // [ADJUST] Objective health display: 0=Off | 1=Shrines only | 2=T1/T2 Towers | 3=Barracks
-"citadel_boss_glow_disabled" "1"
-"citadel_damage_offscreen_indicator_disabled" "1" // Set 1 to disable CREEP HP
-"citadel_portrait_world_renderer_off" "true" // Set true to disable hero hud
-"panorama_use_new_occlusion_invalidation" "1"
-"panorama_temp_comp_layer_min_dimension" "128"
-"panorama_max_overlay_fps" "0"
-"panorama_max_fps" "0"               // [ADJUST] UI FPS cap - 0=Unlimited (smooth UI) | 30/60=Standard | Higher = smoother HUD but more CPU
-"panorama_async_compute_mipgen" "1"
-"citadel_show_new_damage_feedback_numbers" "0" // Set 1 to enable
-"hud_free_cursor" "0"                // Reduces UI input delay in minimap/spectator modes (not sure if this is true)
-"citadel_camera_soft_collision" "2"
-"citadel_camera_wobble_disable" "1"
-"citadel_unit_status_use_new" "0"
-"mm_idle_show_warning_at_s" "999"   // How many seconds to wait before showing the idle warning dialog
-"citadel_hideout_ball_show_juggle_count" "1"
-"citadel_hideout_ball_show_juggle_fx" "1"
-
-// ================ NETWORK & PREDICTION ================
-"cl_prediction_savedata_postentitypacketreceived" "1"
-"r_frame_sync_enable" "0" //was 0
-//"cl_clock_buffer_ticks" "0"          // Testing set 1 to smooth over packet loss
-"cl_async_usercmd_send" "true"
-"cl_smooth" "0"                      // [ADJUST] 0=No smoothing (lower input lag) | 1=Smoothing enabled (may add delay)
-"cl_smoothtime" "0.01"
-"cl_smooth_draw_debug" "0"
-"cl_interp_parallel" "1"
-"cl_parallel_readpacketentities" "1"
-"cl_parallel_readpacketentities_threshold" "2"
-"net_async_clientconnect" "1"
-"engine_max_ticks_to_simulate" "33"
-
-// ================ AI OPTIMIZATIONS ================
-"ai_strong_optimizations_no_checkstand" "1"
-"ai_expression_optimization" "1"
-
-// ================ AUDIO ================
-"audio_enable_vmix_mastering" "0"     // [FPS IMPACT] 0=Off (saves CPU, +FPS) | 1=On (audio mastering enabled)"
-"dsp_volume" "0"                    // idk
-"snd_occlusion_bounces" "0"
-"snd_steamaudio_num_threads" "4"     // [ADJUST] Audio thread count - 1=Low CPU usage | Higher = better audio quality, more CPU By default, it might only use 1 thread. Increasing this allows the heavy sound math to spread out, preventing it from stalling the main game loop during loud teamfights
-"snd_mix_async" "1"
-"soundsystem_update_async" "1"
-
-// ================ TEXTURE STREAMING ================
-"r_texture_pool_size" "256"           // [ADJUST] VRAM usage in MB - Lower = less VRAM used, may cause texture pop-in | 512-1024 range
-"r_texture_stream_mip_bias" "4"         // [FPS IMPACT] Higher = blurrier textures, more FPS | 0=High quality | 2=Balanced | 4=Low quality
-"r_texture_lod_scale" "4"               // [FPS IMPACT] 0=High quality (sharp) | 2=Medium | 4=Low quality (blurry, max FPS)
-"r_fallback_texture_lod_scale" "4"
-"r_texture_budget_update_period" "0.5" // Faster texture streaming adjustment 0.05
-"r_texture_pool_reduce_rate" "512"
-
-// ================ MEMORY BUDGET ================
-"r_texture_budget_dynamic" "1"          // Dynamic texture budget adjustment
-"r_texture_budget_threshold" "0.7"
-
-// ================ SHADER & RENDERING ================
-"mat_async_shader_load" "1"
-"r_renderdoc_auto_shader_pdbs" "0"
-"sc_hdr_enabled_override" "0"
-"r_texturefilteringquality" "0"
-"r_max_portal_render_targets" "2"   // Set how many amount to render portals
-"mat_colcorrection_disableentities" "0" // Disable map color-correction entities
-"r_gbuffer_disable_npr_lighting" "true"
-"r_citadel_npr_outlines" "false"
-
-// test
-"cl_physics_highlight_active" "0" //Turns on the absbox for all active physics objects.<br>  0 : un-highlight.<br>
-"phys_highlight_expensive_objects_strength" "0" //Default: 0.02<br>Highlight expensive physics objects strength, no need since expensive obj is disabled by default
-"r_citadel_shadowdb" "256" //Default: 2048<br>
-"r_citadel_shadow_quality" "0" //Default: 1<br>Shadow Quality
-"r_effects_bloom" "false" //Default: true<br>
-"r_citadel_glow_health_bars" "false" //default true
-"r_citadel_enable_pano_world_blur" "true" //Default: true<br>Enable world-blur style
-"r_depth_of_field" "false" //default true
-"r_directional_lightmaps" "false" //default true
-"r_citadel_distancefield_blur" "false" //Default: true<br>Enable/Disable distance field blur
-"r_citadel_distancefield_shadows" "false" //Default: true<br>
-"mat_max_lighting_complexity" "1" //default 8
-"r_muzzleflashbrightness" "0.01" //default 0.4 idk if this does anything
-"r_particle_cables_render" "true" //default true break lash ult do not disable
-"r_postprocess_enable" "false" //default true
-"lb_dynamic_shadow_resolution" "false" //default true
-"cl_glow_brightness" "0" //default 1
-"r_distancefield_enable" "false" //default true Graphics/Enable Distance Field rendering
-"lb_enable_sunlight" "false" //Default: true<br>SceneSystem/LightBinner/Enable Sunlight
-"citadel_trooper_friendly_glow_disabled" "true" //was false doesnt work btw
-"cl_input_enable_raw_keyboard" "true" //Default: false<br>Enable raw keyboard input
-"r_environment_map_roughness_range" "0.01" //Default: 0.2 0.3<br>Fade region for sampling environment maps on lightmapped nonmetals. Smoother values than the first param sample envmaps. Rougher values than the second sample only lightmap SH. r_environment_map_roughness_range 1 1 to always sample envmaps for comparison. BASICALLY TURN OFF REFLECTIONS ON MAP I THINK
-"lb_cubemap_normalization_max" "1" //Default: 32<br>
-"lb_cubemap_normalization_roughness_begin" "0.01" //Default: 0.1<br>
-"thumper_use_plane_reflection" "false" //Default: true<br>
-"cl_ragdoll_default_scale" "0" //default 1 doesnt matter since ragdoll disabled
-"sc_instanced_mesh_mesh_shader" "false" //default true Toggles mesh shader rendering for instanced meshes
-
-"r_citadel_disable_npr_lighting" "false" //True to make lighting ass, save you just a bit more fps
-
-"r_fullscreen_gamma" "1.4" //recommended ppl to use this to make the game brighter, bigge number = darker (use again in console if game not bright, only work in fullscreen exclusive, try 2.1 then 1.4 to make it work i have 2 keys binded for this)
-
-"mat_colorcorrection" "0"
-"panorama_allow_transitions" "false" //default true turns off UI anim (shop,etc)
-"panorama_disable_blur" "true" //disable ui blur
-//"r_citadel_upscaling" "0" //Default: 4<br> doesnt do anything
-"citadel_trooper_glow_disabled" "true"
-
-"lb_mixed_shadows" "false"
-"r_arealights" "false" //was true
-"r_citadel_antialiasing" "0" //default 1
-"r_character_decal_monitor_render_res" "64" //Default: 512<br>
-"r_citadel_depthoffield_enable" "false"
-"mat_viewportscale" "0.01" //was 1 this controls LOD on everything except trees and bushes (good) for some reason
-"fx_drawmetalspark" "false" //Default: true<br>Draw metal spark effects.
-"r_mapextents" "4500" //Default: 16384<br>Set the max dimension for the map.  This determines the far clipping plane, set to higher number if no like popping building
-"r_citadel_npr_force_solid_outline" "true" //default false
-//"r_dopixelvisibility" "false" //default true enables or disables pixel visibility calculations, which can affect performance and visibility checks within the game.
-"citadel_player_outline_enemies" "false" //turn off enemy outline DOES NOT BREAK BACKSTABBER OR PING THRU WALL
-"sc_screen_size_lod_scale_override" "0.001" //was -1
-"mat_colorcorrection" "0"
-"r_farz" "6000" //default -1 far clipping plane, same as r_mapextents but this affect another thing that i dont understand yet, it gives fps though
-"cl_disable_ragdolls" "true"
-//"citadel_player_glow_disabled" "true" //default false, breaks backstabber
-"citadel_trooper_outline_enabled" "false" //turn off trooper outline
-
-"citadel_hideout_enable_testing_tools" "true" //default false doesnt work
-
-//"r_light_sensitivity_mode" "true"
-
-"phys_cull_internal_mesh_contacts" "true" //default false
-"citadel_use_pvs_for_players" "true" //default false, culls players when out of view
-//"r_particle_max_texture_layers" "3" //was -1
-
-"r_citadel_distancefield_down_sample" "6" //default 1
-
-"ai_gather_conditions_async" "true" //default false
-"enable_priority_boost" "1" 
-
-"update_voices_low_priority" "true" //default false
-"animgraph_enable_parallel_preupdate" "true" //default false Enables parallel processing for the pre-update phase of animation graphs, helping spread the load across more CPU cores
-//"anim_decode_forcewritealltransforms" "true" //Default: false<br>Force BatchAnimationDecode to write transformations for all bones
-//"net_skip_redundant_change_callbacks" "true" //default false im p sure this keep pulling up report screen for some reason
-//"animgraph_footlock_enabled" "false"
-"r_morphing_enabled" "false" 
-"r_smooth_morph_normals" "0"
-
-//"animgraph_slowdownonslopes_enabled" "false"
-"cl_simulate_dormant_entities" "false"
-//"engine_allow_multiple_simulates_per_frame" "false" //default false not sure about this one so dont change it
-
-//"animgraph_enable_parallel_op_evaluation" "true" //default false
-//"animgraph_enable_parallel_preupdate" "true" //false
-"ai_lod_auto_enabled" "true" //default 0, idk about this
-"ai_use_async_ragdoll_fixup" "true" //doesnt really need tbh since ragdoll is disabled
-"cl_phys_networked_start_sleep" "true" //try on and off, this is probably what causing result screen to pop up when idling
-"func_break_max_pieces" "1" //default 15
-
-"r_light_flickering_enabled" "false"
-"sc_clutter_density_none_size" "0.1" //Default 0.0035
-//"r_draw_overlays" "false" //removes the walker line on the ground too, do not recommend
-"snd_mixahead" "0.05" //set to 0.001 if have good CPU, 0.05 adds 50ms to audio mixing thus save CPU perf, should not be perceiveable by any human. 
-//"cl_interp" "0.033" //i would not play with interps
-"r_draw_particle_children_with_parents" "0"
- 
-"r_ssao_blur" "0"
-"r_decals_max_on_deformables" "0"
-"r_particle_cables_render_meshlets" "false" //default true
-"lb_csm_cross_fade_override" "0"
-"lb_csm_distance_fade_override" "0"
-"sc_enable_discard" "true" //default true
-"sc_clutter_density_full_size" "0.5"
-"sc_clutter_density_none_size" "0.1"
-"r_decals_overlap_threshold" "5"
-"r_flashlightbrightness" "0"
-"r_flashlightfar" "0"
-"r_flashlightshadowatten" "0"
-"sc_allow_dithered_lod" "0"
-"sc_dithered_lod_transition_amt" "0"
-
-"lb_dynamic_shadow_penumbra" "false" //default true
-"phys_multithreading_enabled" "1" //default true, alr enabled no need to include ngl
-//"engine_allow_multiple_ticks_per_frame" "0" //remove
-"nav_pathfind_multithread" "1" //default false test 1 and 0, moves npc pathing to separate thread
-
-//"cl_predict_after_every_createmove" "0" // test 1 0 
-//"cl_predictioncopy_runs" "0" //put to 1 if character vibrates
-"r_particle_batch_collections" "1"
-
-"r_texture_stream_resolution_bias" "0.01"
-//"lb_enable_envmaps" "0" //REMOVE THIS DO NOT CHANGE THIS VALUE CUZ EVERYTHING IS GONNA BE BLACK
-"lb_enable_baked_shadows" "1"
-"r_world_wind_frequency_grass" "0"
-"r_world_wind_frequency_trees" "0"
-"mat_tonemap_bloom_scale" "0"
-//"mat_disable_dynamic_shader_compile" "1"
-"lb_barnlight_shadow_use_precomputed_vis" "0"
-"r_low_latency" "1" //Force enabling this for kaiz only, Default: 1<br>NVIDIA Low Latency/AMD Anti-Lag 2 (0 = off, 1 = on, 2 = NV-only, on + boost)
-"mesh_calculate_curvature_smooth_pass_count" "0"
-"panorama_transition_time_factor" "2" //faster transition for the stuff that doesnt use animation
-"phys_dynamic_scaling" "false" //default true
-"phys_expensive_shape_threshold" "100" //was 6
-"sc_max_framebuffer_copies_per_layer" "0" //no idea what this does ngl
-"r_strip_invisible_during_sceneobject_update" "1" //Default: false<br>
-//"fs_async_threads" "17" //was 8
-"props_break_apply_radial_forces" "false"
-//"panorama_min_comp_layer_cache_cost" "256"
-"r_citadel_depth_prepass_dynamic_objects" "0"
-"particle_cluster_use_collision_hulls" "0"
-"citadel_unit_status_old_update_rate" "15"
-"r_pipeline_stats_use_flush_api" "0"
-"sc_instanced_mesh_opaque_fade" "0"
-"g_ragdoll_important_maxcount" "1" 
-"g_ragdoll_maxcount" "1"
-"r_texture_stream_max_resolution" "128"
-"r_texture_nonstreaming_load" "1"
-//"r_indirectlighting" "false"
-"csm_max_num_cascades_override" "2"
-"r_hair_indirect_transmittance" "false"
-//"r_lightmap_bicubic_filtering" "false"
-"r_drawdecals" "false" //defaul true
-"minimap_update_rate_hz" "30"
-"ai_think_interval" "0.3"
-
-"ai_async_queue_max_jobs" "1" //was 8
-"ai_think_interval_lod_med" "0.4"
-"ai_think_interval_lod_low" "1"
-"ai_gather_conditions_async" "true"
-"ai_foot_sweep_enable" "false"
-"wind_system_temporal_smoothing" "false"
-"wind_system_default_resolution_xy" "64"
-"lb_precomputed_shadowmap_enable" "0"
-"lb_shadow_map_cull_empty_mixed" "true"
-"r_citadel_fog_quality" "0"
-"r_citadel_gpu_culling_shadows" "1" //test, was 0
-"r_hair_shadowtile" "false"	
-"vis_sunlight_enable" "0"
-"snd_use_baked_occlusion" "1"
-"citadel_per_weapon_per_surface_impact_effects" "false"
-
-"r_particle_model_per_thread_count" "64"
-"r_limit_particle_job_duration" "1"
-
-"r_citadel_selection_outline2_offset" "2"
-"r_citadel_selection_outline2_alpha" "255"
-"r_citadel_selection_outline2_width" "10"
-"battery_saver" "false"
-"citadel_in_world_item_panel_dpi" "0.5"
-//"citadel_minimap_use_canvas_for_neutrals" "0"
-//"citadel_minimap_use_canvas_for_shop" "0"
-"citadel_npc_disable_floor_point_caching" "false"
-"citadel_npc_force_animate_every_tick" "false"
-"cl_batch_entity_list_ops_during_latch" "1"
-"cl_bone_cache_optimization" "1"
-"cl_particle_batch_mode" "1"
-//"cl_particle_max_count" "1" //max # of particle? doesnt seem to work idk
-"cl_phys_sleep_enable" "1"
-"csm_cascade0_override_dist" "0"
-"csm_cascade1_override_dist" "0"
-"csm_cascade2_override_dist" "0"
-"csm_cascade3_override_dist" "0"
-"csm_max_dist_between_caster_and_receiver" "0"
-"csm_max_visible_dist" "0"
-"csm_res_override_0" "1"
-"csm_res_override_1" "1"
-"csm_res_override_2" "1"
-"csm_res_override_3" "1"
-"csm_viewmodel_shadows" "false"
-"dsp_slow_cpu" "1"
-"engine_low_latency_sleep_after_client_tick" "1"
-"fog_enable" "0" //doesnt work anymore sadly
-"fog_enableskybox" "0"
-"m_rawinput" "1" //doesnt seem to exist in deadlock yet
-"mm_idle_enabled" "false"
-"nav_obstruction_async_update" "true"
-"r_aoproxy_cull_dist" "0.01"
-"r_lightmap_size" "1"
-"r_post_bloom" "0"
-"r_ssao_strength" "0" //alr disabled ssao above shouldnt matter
-"sc_disable_baked_lighting" "false"
-"sc_force_materials_batchable" "true"
-"snd_occlusion_bounces" "0" //try on and off
-"anim_disable" "true"   
-r_citadel_gpu_culling_two_pass "0"
-r_late_particle_job_sync "1"
-//snd_soundmixer_version "1"
-//thread_pool_option "6"
-r_flush_on_pooled_ib_resize "false"
-r_texture_stream_throttle_count_over_budget "0"
-//r_update_particles_on_render_only_frames "1"
-
-"cl_skel_constraints_enable" "0"
-"ik_enable" "0"
-//"panorama_disable_draw_text_shadow" "1"
-"panorama_disable_descendant_filtering" "true"
-
-"net_use_packet_compression" "false"
-"cl_pred_optimize" "true"
-"cl_pred_parallel_postnetwork" "true"
-
-"sc_instanced_mesh_gpu_culling" "true"
-"sc_aggregate_gpu_culling" "true"
-//"sc_disable_procedural_layer_rendering" "true"
-"cl_skip_update_animations" "0" // Puts neutrals in the ground
-
-//"r_skinning_enabled" "0" //turns everything into tpose
-"cl_phys_animated_hierarchy" "false"
-"phys_continuous_kinematic_update" "0"
-
-"snd_disable_mixer_duck" "1"
-"lb_enable_newsum" "0"
-
-"lb_csm_draw_alpha_tested" "0"                   // Stops calculating shadow alpha on fences/leaves
-"lb_shadow_texture_width_override" "16"          // Shrinks the global shadow atlas to 16 pixels
-"lb_shadow_texture_height_override" "16"         // Shrinks the global shadow atlas to 16 pixels
-"sparseshadowtree_disable_add_layers" "1"        // Completely breaks Sparse Shadow Tree layering
-"mat_slopescaledepthbias_shadowmap" "0"          // Disables shadow depth bias math
-"mat_depthbias_shadowmap" "0"                    // Disables shadow depth bias math
-"sc_allow_dynamic_constant_batching" "1"
-
-"sc_disable_culling_boxes" "1"       // Skips calculating bounding boxes for culling
-//"sc_disable_world_materials" "1"     // Turns the entire map gray (strips all materials from the world)
-//"r_draw_instances" "0"               // Deletes small props and details from the map entirely
-"r_flashlightambient" "0"            // Disables ambient lighting math on flashlights/muzzle flashes
-"r_flashlightconstant" "0"           // Disables constant lighting math
-
-"sc_allow_precomputed_vismembers" "1"
-"sc_barnlight_enable_precomputed_vis" "1"
-"lb_barnlight_shadow_use_precomputed_vis" "1"
-"sc_force_single_display_list_per_layer" "1"
-"sc_aggregate_gpu_occlusion_culling" "1"
-"sc_aggregate_gpu_vis_culling" "1"
-
-"citadel_damage_indicator_radius" "1"
-"citadel_damage_indicator_height" "10"
-"citadel_damage_indicator_width" "10"
-"citadel_damage_text_lifetime" "0.01"
-"citadel_damage_text_lifetime_new" "0.1"
-"r_threaded_particles" "1"
-
-"panorama_enable_secondary_layout_pass" "0"     // Skips the secondary CSS layout check (drastically reduces UI calculation time)
-"panorama_draw_text_fast_path" "1"              // Forces text rendering through a hardware fast-path
-"panorama_draw_text_fast_path_text_shadow" "1"  // Forces text shadows through a hardware fast-path
-"panorama_hsbc_through_fast_path" "1"           // Forces UI hue/saturation/brightness changes through a fast-path
-"panorama_use_backbuffer_directly" "1"          // Skips copying the UI buffer to memory and writes directly to the backbuffer
-"panorama_script_cache_enabled" "1"             // Aggressively caches UI Javascript to prevent mid-game recompilation
-"citadel_unit_status_hide_names" "1"         // Removes player names from health bars (text rendering is heavy).
-"citadel_hud_objective_health_idle_timeout" "0" // Boss/Tower health bars vanish the millisecond they stop taking damage.
-"citadel_camera_parrot_smoothing_rate" "0"   // Stops the camera from running math to "smooth" itself back into place after hitting a wall.
-//"steam_inputhandler_enabled" "0"             // Completely disables Steam Input API polling. Huge for 1% lows if you only use Keyboard/Mouse.
-
-"panorama_clear_frames_on_device_restore" "0"
-
-
-
-
-		"rate"
-		{
-			"min"		"98304"
-			"default"	"786432"
-			"max"		"1000000"
-		}
-		"sv_minrate"	"98304"
-		"sv_maxunlag"	"0.500"
-		"sv_maxunlag_player" "0.200"
-		"sv_lagcomp_filterbyviewangle" "false"
-
-		// Spew warning when adding/removing classes to/from the top of the hierarchy
-		"panorama_classes_perf_warning_threshold_ms" "0.75"
-
-		// Panorama - enable minidumps on JS exceptions
-		"panorama_js_minidumps" "1"
-		// Enable the render target cache optimization.
-		"panorama_disable_render_target_cache" "0"
-
-		// Enable the composition layer optimization
-		"panorama_skip_composition_layer_content_paint" "1"
-
-		// too expensive (500MB+) to load this
-		"snd_steamaudio_load_reverb_data" "0"
-		"snd_steamaudio_load_pathing_data" "0"
-
-		// Steam Audio project specific convars
-		"snd_steamaudio_enable_custom_hrtf"		"0"
-		"snd_steamaudio_active_hrtf"			"0"
-		"snd_steamaudio_reverb_update_rate"		"10.0"
-		"snd_steamaudio_ir_duration"			"1.0"
-		"snd_steamaudio_enable_pathing"			"0"
-		"snd_steamaudio_invalid_path_length"	"0.0"
-		"cl_disconnect_soundevent"				"citadel.convar.stop_all_game_layer_soundevents"
-		"snd_event_browser_default_stack"		"citadel_default_3d"
-		
-		// voip
-		"voice_in_process"			            "1"
-
-		// Sound debugging
-		"snd_report_audio_nan" "1"
-
-		// Audio system settings
-		"snd_sos_max_event_base_depth" "10"
-		"sos_use_guid_filter" "1"
-
-		"voice_always_sample_mic"               
-		{
-			"version"	"2"
-			"default"	"0"
-		}
-
-		"reset_voice_on_input_stallout"         "0"
-		"voice_input_stallout"                  "0.5"
-		"cl_usesocketsforloopback" "1"
-		"cl_poll_network_early" "0"
-
-		// Perf/Parallelism
-		"iv_parallel_restore" "1"
-
-		// For perf reasons, since we don't use source-based DSP:
-		"disable_source_soundscape_trace"       "1"
-		
-		// Networking - Induced latency (pred offset)
-		"cl_tickpacket_recvmargin_desired" "5" 					// 5 ms base, min. floor for protecting against thrashing the queue
-		"cl_tickpacket_desired_queuelength" "0"					// 0 = attempt to always reach the queue's min floor
-		"cl_async_usercmd_send_disabled_recvmargin_min" "0.5"	// Additional frame since we do not use the async usercmd send (potentially unneccessary)
-		"cl_clock_buffer_ticks"	"1"
-		"cl_interp_ratio" "0"
-		"cl_async_usercmd_send" "false"
-
-		"fps_max"		"400"
-		"fps_max_ui"	"120"
-
-		"in_button_double_press_window" "0.3"
-
-		// Convars that control spatialization of UI audio.
-		"snd_ui_positional"								"1"
-		"snd_ui_spatialization_spread"					"2.4"
-		
-		// sound volume rate change limiting
-		"snd_envelope_rate"								"100.0"
-		"snd_soundmixer_update_maximum_frame_rate" 		"0"
-
-		//don't let people mess with speaker config settings.
-		"speaker_config"
-		{
-			"min"		"0"
-			"default"	"0"
-			"max"		"2"
-		}
-
-		"cq_buffer_bloat_msecs_max" "120"
-
-		"snd_soundmixer"						"Default_Mix"
-		"cloth_filter_transform_stateless" "0"
-
-		"cl_joystick_enabled" "0"
-		"panorama_joystick_enabled" "0"
-
-		"snd_event_browser_focus_events" "true"
-
-		"cl_max_particle_pvs_aabb_edge_length" "100"
-		
-		// Allow aggregation of particles (for perf)
-		"cl_aggregate_particles" "true"
-		
-		"citadel_enable_vdata_sound_preload" "true"
-	}
-
-	Memory
-	{
-		"EstimatedMaxCPUMemUsageMB"	"1"
-		"EstimatedMinGPUMemUsageMB"	"1"
-
-		"ShowInsufficientPageFileMessageBox" "1"
-		"ShowLowAvailableVirtualMemoryMessageBox" "1"
-	}
+    game        "citadel"
+    title       "Citadel"
+    type        "multiplayer_only"
+    nomodels    "1"
+    nohimodel   "1"
+    nocrosshair "0"
+    hidden_maps
+    {
+        test_speakers "1"
+        test_hardware "1"
+    }
+    nodegraph   "0"
+    perfwizard  "0"
+    tonemapping "0"
+    GameData    "citadel.fgd"
+
+    DisallowGameInfoConditionals "1"
+    PGIVersion                   "6E09D3ED5A47F6A97443813F0E00F90BAA435918F82DF0C9B5DA46D27A33D903"
+
+    Localize
+    {
+        DuplicateTokensAssert "1"
+        DisallowTokenContexts "1"
+    }
+
+    SupportedLanguages
+    {
+        brazilian  "3"
+        czech      "3"
+        english    "3"
+        french     "3"
+        german     "3"
+        italian    "3"
+        indonesian "3"
+        japanese   "3"
+        koreana    "3"
+        latam      "3"
+        polish     "3"
+        russian    "3"
+        schinese   "3"
+        spanish    "3"
+        thai       "3"
+        turkish    "3"
+        ukrainian  "3"
+    }
+
+    FileSystem
+    {
+        //
+        // The code that loads this file automatically does a few things here:
+        //
+        // 1. For each "Game" search path, it adds a "GameBin" path, in <dir>\bin
+        // 2. For each "Game" search path, it adds another "Game" path in front of it with _<language> at the end.
+        //    For example: c:\hl2\cstrike on a french machine would get a c:\hl2\cstrike_french path added to it.
+        // 3. If no "Mod" key, for the first "Game" search path, it adds a search path called "MOD".
+        // 4. If no "Write" key, for the first "Game" search path, it adds a search path called "DEFAULT_WRITE_PATH".
+        //
+
+        //
+        // Search paths are relative to the exe directory\..\
+        //
+        SearchPaths
+        {
+            // These are optional language paths. They must be mounted first, which is why there are first in the list.
+            // *LANGUAGE* will be replaced with the actual language name. If not running a specific language, these paths will not be mounted
+            Game_Language "citadel_*LANGUAGE*"
+
+            // These are optional low-violence paths. They will only get mounted if you're in a low-violence mode.
+            Game_LowViolence "citadel_lv"
+            Game             "citadel/addons"
+            Mod              "citadel"
+            Write            "citadel"
+            Game             "citadel"
+            Game             "core"
+        }
+    }
+
+    MaterialSystem2
+    {
+        RenderModes
+        {
+            game "Default"
+            game "Forward"
+            game "Deferred"
+            game "Outline"
+            game "Depth"
+            game "FrontDepth"
+
+            dev "ToolsVis"       // Visualization modes for all shaders (lighting only, normal maps only, etc.)
+            dev "ToolsWireframe" // This should use the ToolsVis mode above instead of being its own mode\
+
+            tools "ToolsUtil" // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
+        }
+    }
+
+    MaterialEditor
+    {
+        DefaultShader "environment_texture_set"
+    }
+
+    NetworkSystem
+    {
+        BetaUniverse
+        {
+            FakeLag             "40"
+            FakeLoss            ".1"
+            // FakeReorderPct   "0.05"
+            // FakeReorderDelay "10"
+            // FakeJitter       "low"
+            // Turning off fake jitter for now while I work on making the CQ totally solid
+            FakeReorderPct   "0"
+            FakeReorderDelay "0"
+            FakeJitter       "off"
+        }
+
+        SkipRedundantChangeCallbacks "1"
+    }
+
+    RenderSystem
+    {
+        IndexBufferPoolSizeMB              "32"
+        UseReverseDepth                    "1"
+        Use32BitDepthBuffer                "0"
+        Use32BitDepthBufferWithoutStencil  "0"
+        SwapChainSampleableDepth           "1"
+        VulkanMutableSwapchain             "1"
+        LowLatency                         "1"
+        VulkanOnly_Linux                   "1"
+        VulkanRequireSubgroupWaveOpSupport "1"
+        VulkanRequireDescriptorIndexing    "1"
+        VulkanSteamShaderCache             "1"
+        VulkanSteamAppShaderCache          "1"
+        VulkanSteamDownloadedShaderCache   "1"
+        VulkanAdditionalShaderCache        "vulkan_shader_cache.foz"
+        VulkanStagingPMBSizeLimitMB        "384"
+        GraphicsPipelineLibrary            "1"
+        VulkanOnlyTestProbability          "0"
+        VulkanDefrag                       "1"
+        MinStreamingPoolSizeMB             "1024"
+        MinStreamingPoolSizeMBTools        "2048"
+    }
+
+    NVNGX
+    {
+        AppID        "103371621"
+        SupportsDLSS "1"
+    }
+
+    Engine2
+    {
+        HasModAppSystems "1"
+        Capable64Bit     "1"
+        URLName          "citadel"
+        RenderingPipeline
+        {
+            SupportsMSAA  "0"
+            DistanceField "1"
+        }
+        PauseSinglePlayerOnGameOverlay "1"
+        DefensiveConCommands           "1"
+        DisableLoadingPlaque           "1"
+    }
+
+    ContentBuilder
+    {
+        ResourceCompilerDirectXUsesWARP "0"
+    }
+
+    SoundSystem
+    {
+        SteamAudioEnabled   "1"
+        WaveDataCacheSizeMB "256"
+        UsePlatTime         "1"
+    }
+    Sounds
+    {
+        HierarchicalEncodingFiles "1"
+    }
+
+    ToolsEnvironment
+    {
+        Engine   "Source 2"
+        ToolsDir "../sdktools" // NOTE: Default Tools path. This is relative to the mod path.
+    }
+
+    pulse
+    {
+        pulse_enabled "1"
+    }
+
+    Hammer
+    {
+        fgd                           "citadel.fgd" // NOTE: This is relative to the 'game' path.
+        GameFeatureSet                "Citadel"
+        DefaultSolidEntity            "trigger_multiple"
+        DefaultPointEntity            "info_player_start"
+        NavMarkupEntity               "func_nav_markup"
+        OverlayBoxSize                "8"
+        TileMeshesEnabled             "1"
+        RenderMode                    "ToolsVis"
+        CreateRenderClusters          "1"
+        DefaultMinDrawVolumeSize      "2048"
+        DefaultMinTrianglesPerCluster "16384"
+        TileGridSupportsBlendHeight   "1"
+        TileGridBlendDefaultColor     "0 255 0"
+        LoadScriptEntities            "0"
+        UsesBakedLighting             "1"
+        UseAnalyticGrid               "0"
+        SupportsDisplacementMapping   "0"
+        SteamAudioEnabled             "1"
+        LatticeDeformerEnabled        "1"
+        ShadowAtlasWidth              "16384"
+        ShadowAtlasHeight             "16384"
+        TimeSlicedShadowMapRendering  "1"
+    }
+
+    SoundTool
+    {
+        DefaultSoundEventType "src1_3d"
+
+        SoundEventBaseOptions
+        {
+            Base.Announcer.VO.2d     ""
+            Base.World.VO.Emitter.3d ""
+            Base.Hero.VO.Ping.2d     ""
+            Base.Hero.VO.2d          ""
+            Base.Hero.VO.3d          ""
+            Base.Hero.VO.Ability.3d  ""
+            Base.Hero.VO.Ultimate.3d ""
+            Base.Hero.VO.Dash.3d     ""
+            Base.Hero.VO.Effort.3d   ""
+            Base.Hero.VO.Pain.3d     ""
+            Base.Hero.VO.Melee.3d    ""
+            Base.Hero.VO.Death.3d    ""
+        }
+    }
+
+    RenderPipelineAliases
+    {
+    }
+
+    ResourceCompiler
+    {
+        // Overrides of the default builders as specified in code, this controls which map builder steps
+        // will be run when resource compiler is run for a map without specifiying any specific map builder
+        // steps. Additionally this controls which builders are displayed in the hammer build dialog.
+        DefaultMapBuilders
+        {
+            bakedlighting "1" // Enable lightmapping during compile time
+            envmap        "0" // turned off since it currently causes an assert and doesn't work due to some build issue
+            nav           "1" // Generate nav mesh data
+        }
+
+        MeshCompiler
+        {
+            OptimizeForMeshlets       "1"
+            TrianglesPerMeshlet       "64" // Maximum valid value currently is 126
+            UseMikkTSpace             "1"
+            EncodeVertexBuffer        "1"
+            EncodeVertexBufferVersion "1"
+            EncodeVertexBufferLevel   "3"
+            EncodeIndexBuffer         "1"
+            SplitDepthStream          "1"
+        }
+
+        WorldRendererBuilder
+        {
+            VisibilityGuidedMeshClustering     "1"
+            MinimumTrianglesPerClusteredMesh   "8192"
+            MinimumVerticesPerClusteredMesh    "8192"
+            MinimumVolumePerClusteredMesh      "8192" // ~20x20x20 cube
+            MaxPrecomputedVisClusterMembership "96"
+            MaxCullingBoundsGroups             "128"
+            UseAggregateInstances              "1"
+            AggregateInstancingMeshlets        "1"
+            BakePropsWithExtraVertexStreams    "1"
+        }
+
+        BakedLighting
+        {
+            Version                          "4"
+            ImportanceVolumeTransitionRegion "512" // distance we transition from high to low resolution charts
+            LightmapChannels
+            {
+                direct_light_shadows          "1"
+                debug_chart_color             "1"
+                directional_irradiance_sh2_dc "1"
+
+                directional_irradiance_sh2_r
+                {
+                    CompressedFormat "DXT1"
+                }
+
+                directional_irradiance_sh2_g
+                {
+                    CompressedFormat "DXT1"
+                }
+
+                directional_irradiance_sh2_b
+                {
+                    CompressedFormat "DXT1"
+                }
+            }
+            LightmapGutterSize   "2" // For bicubic filtering
+            UseStaticLightProbes "0"
+            LPVAtlas             "1"
+            BC6HHueShiftFixup    "0" // Causes more artifacts than it solves atm
+            Repack2              "1"
+        }
+
+        SteamAudio
+        {
+            ReverbDefaults
+            {
+                GridSpacing      "3.0"
+                HeightAboveFloor "1.5"
+                RebakeOption     "0" // 0: cleanup, 1: manual, 2: auto
+                NumRays          "32768"
+                NumBounces       "64"
+                IRDuration       "1.0"
+                AmbisonicsOrder  "1"
+            }
+            PathingDefaults
+            {
+                GridSpacing       "3.0"
+                HeightAboveFloor  "1.5"
+                RebakeOption      "0" // 0: cleanup, 1: manual, 2: auto
+                NumVisSamples     "1"
+                ProbeVisRadius    "0"
+                ProbeVisThreshold "0.1"
+                ProbeVisPathRange "1000.0"
+            }
+        }
+        SoundStackScripts
+        {
+            CompileStacksStrict "1"
+        }
+        VisBuilder
+        {
+            MaxVisClusters                     "4096"
+            PreMergeOpenSpaceDistanceThreshold "128.0"
+            PreMergeOpenSpaceMaxDimension      "2048.0"
+            PreMergeOpenSpaceMaxRatio          "8.0"
+            PreMergeSmallRegionsSizeThreshold  "20.0"
+        }
+
+        VDataLocalization
+        {
+            GameOutputPath "resource/localization/citadel_vdata"
+            TokenPrefix    "Citadel_VData_"
+        }
+
+        TextureCompiler
+        {
+            // Compressor               "lz4"
+            // CompressMipsOnDisk       "1"
+            // CompressMinRatio         "95"
+            AllowNP2Textures            "1"
+            AllowPanoramaMipGeneration  "1"
+            // PublicToolsDefaultMaxRes "2048"
+        }
+    }
+
+    Source1Import
+    {
+        // this is just copied from the left4dead3 gameinfo.gi
+        forcevtxfileupconvert "1"
+    }
+
+    WorldRenderer
+    {
+        EnvironmentMaps             "1"
+        EnvironmentMapFaceSize      "256"
+        EnvironmentMapRenderSize    "1024"
+        EnvironmentMapFormat        "BC6H"
+        EnvironmentMapPreviewFormat "BC6H"
+        EnvironmentMapColorSpace    "linear"
+        EnvironmentMapMipProcessor  "GGXCubeMapBlur"
+        // Build cubemaps into a cube array instead of individual cubemaps.
+        EnvironmentMapUseCubeArray   "1"
+        EnvironmentMapCacheSizeTools "300"
+        BindlessSceneObjectDesc      "CitadelBindlessDesc"
+        GrassCastsShadows            "1"
+    }
+
+    SceneSystem
+    {
+        GpuLightBinner                 "1"
+        FogCachedShadowAtlasWidth      "0"
+        FogCachedShadowAtlasHeight     "0"
+        FogCachedShadowTileSize        "0"
+        GpuLightBinnerSunLightFastPath "1"
+        CSMCascadeResolution           "0"
+        SunLightManagerCount           "0"
+        SunLightManagerCountTools      "0"
+        DefaultShadowTextureWidth      "0"
+        DefaultShadowTextureHeight     "0"
+        DynamicShadowResolution        "0"
+
+        TransformTextureRowCount          "1024"
+        TransformTextureRowCountToolsMode "6144"
+        SunLightMaxCascadeSize            "4"
+        SunLightShadowRenderMode          "Depth"
+        LayerBatchThresholdFullsort       "20"
+        NonTexturedGradientFog            "0"
+        // Temp till I can add support in citadel shaders
+        DisableLateAllocatedTransformBuffer         "1"
+        MinimumLateAllocatedVertexCacheBufferSizeMB "64"
+        CubemapFog                                  "0"
+        VolumetricFog                               "0"
+        FrameBufferCopyFormat                       "R11G11B10F"
+        Tonemapping                                 "0"
+
+        WellKnownLightCookies
+        {
+            blank      "materials/effects/lightcookies/blank.vtex"
+            flashlight "materials/effects/lightcookies/flashlight.vtex"
+        }
+
+        ComputeShaderSkinning "1"
+    }
+
+    NavSystem
+    {
+        NavTileSize   "128.0"
+        NavCellSize   "1.5"
+        NavCellHeight "2.0"
+
+        // Hull definitions live in scripts/nav_hulls.vdata
+        // Preset definitions live in scripts/nav_hulls_presets.vdata
+        NavHullsPreset "default"
+
+        NavRegionMinSize              "8"
+        NavRegionMergeSize            "20"
+        NavEdgeMaxLen                 "1200"
+        NavEdgeMaxError               "51.0"
+        NavVertsPerPoly               "4"
+        NavDetailSampleDistance       "120.0"
+        NavDetailSampleMaxError       "2.0"
+        NavSmallAreaOnEdgeRemovalSize "81.0"
+    }
+
+    AnimationSystem
+    {
+        DisableServerInterpCompensation "1"
+        DisableAnimationScript          "1"
+        ServerPoseRecipeHistorySize     "60"
+        ClientPoseRecipeHistorySize     "60"
+
+    }
+
+    ModelDoc
+    {
+        models_gamedata "models_gamedata.fgd"
+        features        "animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
+    }
+
+    Particles
+    {
+        EnableParticleShaderFeatureBranching "1"
+        Float16HDRBackBuffer                 "1"
+        PET_SupportFadingOpaqueModels        "1"
+        Features                             "non_homogenous_forward_layer_only"
+    }
+
+    ConVars
+    {
+        // ================ CORE QUALITY ================
+        gpu_level              "1" // Minimum Shader Details Level 0= high
+        cpu_level              "1" // Minimum Effect Details Level
+        mat_set_shader_quality "0"
+
+        // ================ FOV ================
+        r_aspectratio "2.3" // [ADJUST] FOV control: 1.33=70fov | 1.56=75fov | 1.75=80fov | 2.0=85fov | 2.15=90fov | 2.49=100fov | 3.0=110fov | 3.5=120fov
+
+        // ================ LIGHTING & SHADOWS ================
+        r_directlighting                                       "false"
+        r_ssao                                                 "false" // Disable ambient occlusion
+        r_shadows                                              "0"     // [FPS IMPACT] 0=Off (max FPS) | 1=On (shadows enabled)
+        r_rendersun                                            "0"
+        lb_enable_shadow_casting                               "0" // [FPS IMPACT] 0=Off (shadows disabled, +FPS) | 1=On (shadow casting enabled)
+        lb_csm_draw_alpha_tested                               "0"
+        lb_csm_draw_translucent                                "0"
+        lb_barnlight_shadowmap_scale                           "0.01" //default 0.5
+        lb_csm_cascade_size_override                           "0.25" //was 1
+        lb_dynamic_shadow_resolution_quantization              "32"   //64
+        lb_csm_override_staticgeo_cascades_value               "0"
+        lb_csm_receiver_plane_depth_bias                       "0.00002"
+        lb_csm_receiver_plane_depth_bias_transmissive_backface "0.0002"
+        lb_sun_csm_size_cull_threshold_texels                  "30"
+        lb_dynamic_shadow_resolution_base                      "32"
+        lb_enable_fog_mixed_shadows                            "0"
+        r_citadel_sun_shadow_slope_scale_depth_bias            "1.0" //was 1
+        r_lightmap_size_directional_irradiance                 "0"   //was 4
+        r_size_cull_threshold_shadow                           "200" //Default: 100<br>Threshold of shadow map size percentage below which objects get culled
+        csm_max_shadow_dist_override                           "1500"
+        sc_cache_envmap_lpv_lookup                             "false" //was true
+        cl_retire_low_priority_lights                          "1"
+        sc_disable_spotlight_shadows                           "1"
+        sc_disable_shadow_materials                            "1"
+        cl_globallight_shadow_mode                             "0"
+        lb_enable_dynamic_lights                               "0"
+        lb_enable_lights                                       "0" //was 1
+        lb_enable_stationary_lights                            "0" // Disable stationary lights
+        lb_max_visible_barn_lights_override                    "1"
+        // lb_max_visible_envmaps_override                     "4" //default 4 DO NOT CHANGE OR IT BREAKS GAME
+        lb_ssss_samples                                        "0"
+        // r_multiscattering                                   "0" // Disable multiscattering (only works with shadows disable)
+
+        // ================ SPARSE SHADOW TREE ================
+        sparseshadowtree_enable_rendering      "0"
+        sparseshadowtree_disable_for_viewmodel "1"
+
+
+        // ================ DISTANCE FIELD ================
+        r_citadel_distancefield_farfield_enable "false"
+        r_citadel_npr_outlines_max_dist         "600"
+
+        // ================ FOG & ATMOSPHERE ================
+        r_enable_volume_fog                  "0"
+        r_enable_gradient_fog                "0"
+        r_enable_cubemap_fog                 "0"
+        volume_fog_intermediate_textures_hdr "0"
+
+        // ================ SKY & ENVIRONMENT ================
+        r_draw3dskybox        "0"
+        r_drawskybox          "0" // Set to 0 to disable skybox
+        r_monitor_3dskybox    "0"
+        r_world_wind_strength "0"
+
+        // ================ SSAO ================
+        r_citadel_ssao_bent_normals               "false"
+        r_citadel_ssao_denoise_passes             "0"
+        r_citadel_ssao_quality                    "0"
+        r_citadel_ssao_radius                     "0"
+        r_citadel_ssao_thin_occluder_compensation "0"
+
+        // ================ PARTICLE SYSTEM ================
+        r_particle_max_detail_level              "0 " //was 0
+        r_particle_cables_cast_shadows           "0"
+        r_RainParticleDensity                    "0"
+        r_physics_particle_op_spawn_scale        "0"
+        r_particle_max_size_cull                 "1200" //was 800 Particle systems larger than this in every dimension skip culling to save CPU.  They will be drawn anyway
+        particle_cluster_nodraw                  "1"
+        r_particle_mixed_resolution_viewstart    "800"
+        r_particle_max_draw_distance             "300000" // Lower = less particle range, more FPS, dont go below this value it doesnt draw trooper hp bar,
+        r_particle_model_new8                    "0"
+        cl_show_splashes                         "0"
+        r_particle_skip_postsim                  "1"
+        r_limit_particle_job_duration            "1"
+        cl_particle_sim_fallback_threshold_ms    "0" // [ADJUST] Lower = more aggressive fallback to simple particles (higher FPS, less detail)
+        cl_particle_fallback_base                "10"
+        cl_particle_fallback_multiplier          "10"  //was 10
+        cl_particle_sim_fallback_base_multiplier "100" //default 10
+        r_particle_min_timestep                  "0.001"
+
+        // ================ PHYSICS & CLOTH ================
+        cloth_update               "1" // [FPS IMPACT] 0=Off (cosmetic only, +FPS) | 1=On (cloth physics enabled)
+        cloth_sim_on_tick          "0"
+        presettle_cloth_iterations "0"      //default 3
+        pred_cloth_pos_max         "0"      // Reduce cloth prediction was 1
+        pred_cloth_pos_multiplier  "0"      //was 0.3
+        pred_cloth_pos_strength    "0"      //was 0.1
+        pred_cloth_rot_high        "0"      //was 0.05
+        pred_cloth_rot_low         "0"      //was 0.005
+        pred_cloth_rot_multiplier  "0"      //was 0.2 changing these values does fucking nothing
+        cl_phys_timescale          "1"      // [FPS IMPACT] 0=Disable physics (max FPS) | 1=Normal physics | Lower = slower physics, less CPU
+        cl_fasttempentcollision    "999999" //test Temp Entities" are things like shell casings hitting the floor. Increasing this number usually tells the engine to skip collision checks for them entirely or expire them instantly to avoid physics costs.
+
+        phys_threaded_cloth_bone_update     "1"
+        phys_threaded_kinematic_bone_update "1"
+        phys_threaded_transform_update      "1"
+
+        // ================ RAGDOLL ================
+        cl_ragdoll_limit              "0" // Set it on console if ragdoll still lingers longer
+        ragdoll_parallel_pose_control "1"
+
+        // ================ MODEL & DECAL OPTIMIZATIONS ================
+        r_drawmodeldecals                        "0"    //does not exist in master convar
+        r_character_decal_resolution             "0.01" //default 1
+        r_decals                                 "1"    // im p sure valve killed this command [ADJUST] Max decals visible: 1= only 1 bullet hole(max FPS) | 16=default
+        r_propsmaxdist                           "600"
+        props_break_max_pieces_perframe          "1" //was 2
+        r_citadel_screenspace_particles_full_res "0"
+        r_citadel_gpu_culling_shadows            "1"
+        skeleton_instance_lod_optimization       "1"
+        r_size_cull_threshold                    "1.2" // do not go over or youll have wall hack
+        r_hair_ao                                "0"
+        r_render_hair                            "0" // doesnt work [FPS IMPACT] 0=Off (max FPS boost, bald heroes) | 1=On (hair rendered)
+        r_haircull_percent                       "100"
+        ik_final_fixup_enable                    "0"
+        ik_fabrik_align_chain                    "0"
+        cl_impacteffects                         "0"
+        enable_boneflex                          "false" // cloth flexing
+        cl_eye_yaw_multiplier                    "0"
+
+        // ================ LOD & CULLING ================
+        sc_instanced_mesh_lod_bias              "15" // [FPS IMPACT] Higher = lower quality models, more FPS | 0=High quality | 10=Low quality
+        sc_instanced_mesh_lod_bias_shadow       "10" // Bias for LOD selection of instanced meshes in shadowmaps
+        sc_instanced_mesh_motion_vectors        "0"  // Set 1 if you use motion blur
+        sc_instanced_mesh_size_cull_bias        "10" // Bias for size culling of instanced meshes
+        sc_instanced_mesh_size_cull_bias_shadow "10" // Bias for size culling instanced meshes in shadowmaps
+        sc_fade_distance_scale_override         "180"
+        sc_clutter_enable                       "false" // [FPS IMPACT] 0=No debris/props (max FPS) | 1=Props visible (immersive)
+        sc_aggregate_bvh_threshold              "16"    // Lower BVH threshold (default: 128)
+        sc_layer_batch_threshold                "16"    // Lower batch threshold (default: 128)
+        sc_layer_batch_threshold_fullsort       "20"    //default 80
+
+        // ================ ROPE PHYSICS ================
+        rope_collide              "0"
+        rope_subdiv               "0"
+        rope_wind_dist            "0"
+        rope_smooth_enlarge       "0"
+        rope_smooth_maxalpha      "0"
+        rope_smooth_maxalphawidth "0"
+        rope_smooth_minalpha      "0"
+        rope_smooth_minwidth      "0"
+        r_ropetranslucent         "0"
+        r_drawropes               "0"
+
+        // ================ TERRAIN & FOLIAGE ================
+        r_grass_quality    "0"
+        r_grass_start_fade "0"
+        r_grass_end_fade   "0"
+
+        // ================ UI & HUD ================
+        panorama_disable_box_shadow                 "1"
+        r_dashboard_render_quality                  "0"
+        closecaption                                "false"
+        citadel_hud_objective_health_enabled        "2" // [ADJUST] Objective health display: 0=Off | 1=Shrines only | 2=T1/T2 Towers | 3=Barracks
+        citadel_boss_glow_disabled                  "1"
+        citadel_damage_offscreen_indicator_disabled "1"    // Set 1 to disable CREEP HP
+        citadel_portrait_world_renderer_off         "true" // Set true to disable hero hud
+        panorama_use_new_occlusion_invalidation     "1"
+        panorama_temp_comp_layer_min_dimension      "128"
+        panorama_max_overlay_fps                    "0"
+        panorama_max_fps                            "0" // [ADJUST] UI FPS cap - 0=Unlimited (smooth UI) | 30/60=Standard | Higher = smoother HUD but more CPU
+        panorama_async_compute_mipgen               "1"
+        citadel_show_new_damage_feedback_numbers    "0" // Set 1 to enable
+        hud_free_cursor                             "0" // Reduces UI input delay in minimap/spectator modes (not sure if this is true)
+        citadel_camera_soft_collision               "2"
+        citadel_camera_wobble_disable               "1"
+        citadel_unit_status_use_new                 "0"
+        mm_idle_show_warning_at_s                   "999" // How many seconds to wait before showing the idle warning dialog
+        citadel_hideout_ball_show_juggle_count      "1"
+        citadel_hideout_ball_show_juggle_fx         "1"
+
+        // ================ NETWORK & PREDICTION ================
+        cl_prediction_savedata_postentitypacketreceived "1"
+        r_frame_sync_enable                             "0" //was 0
+        // cl_clock_buffer_ticks                        "0" // Testing set 1 to smooth over packet loss
+        cl_async_usercmd_send                           "true"
+        cl_smooth                                       "0" // [ADJUST] 0=No smoothing (lower input lag) | 1=Smoothing enabled (may add delay)
+        cl_smoothtime                                   "0.01"
+        cl_smooth_draw_debug                            "0"
+        cl_interp_parallel                              "1"
+        cl_parallel_readpacketentities                  "1"
+        cl_parallel_readpacketentities_threshold        "2"
+        net_async_clientconnect                         "1"
+        engine_max_ticks_to_simulate                    "33"
+
+        // ================ AI OPTIMIZATIONS ================
+        ai_strong_optimizations_no_checkstand "1"
+        ai_expression_optimization            "1"
+
+        // ================ AUDIO ================
+        audio_enable_vmix_mastering "0" // [FPS IMPACT] 0=Off (saves CPU, +FPS) | 1=On (audio mastering enabled)"
+        dsp_volume                  "0" // idk
+        snd_occlusion_bounces       "0"
+        snd_steamaudio_num_threads  "4" // [ADJUST] Audio thread count - 1=Low CPU usage | Higher = better audio quality, more CPU By default, it might only use 1 thread. Increasing this allows the heavy sound math to spread out, preventing it from stalling the main game loop during loud teamfights
+        snd_mix_async               "1"
+        soundsystem_update_async    "1"
+
+        // ================ TEXTURE STREAMING ================
+        r_texture_pool_size            "256" // [ADJUST] VRAM usage in MB - Lower = less VRAM used, may cause texture pop-in | 512-1024 range
+        r_texture_stream_mip_bias      "4"   // [FPS IMPACT] Higher = blurrier textures, more FPS | 0=High quality | 2=Balanced | 4=Low quality
+        r_texture_lod_scale            "4"   // [FPS IMPACT] 0=High quality (sharp) | 2=Medium | 4=Low quality (blurry, max FPS)
+        r_fallback_texture_lod_scale   "4"
+        r_texture_budget_update_period "0.5" // Faster texture streaming adjustment 0.05
+        r_texture_pool_reduce_rate     "512"
+
+        // ================ MEMORY BUDGET ================
+        r_texture_budget_dynamic   "1" // Dynamic texture budget adjustment
+        r_texture_budget_threshold "0.7"
+
+        // ================ SHADER & RENDERING ================
+        mat_async_shader_load             "1"
+        r_renderdoc_auto_shader_pdbs      "0"
+        sc_hdr_enabled_override           "0"
+        r_texturefilteringquality         "0"
+        r_max_portal_render_targets       "2" // Set how many amount to render portals
+        mat_colcorrection_disableentities "0" // Disable map color-correction entities
+        r_gbuffer_disable_npr_lighting    "true"
+        r_citadel_npr_outlines            "false"
+
+        // test
+        cl_physics_highlight_active               "0"     //Turns on the absbox for all active physics objects.<br>  0 : un-highlight.<br>
+        phys_highlight_expensive_objects_strength "0"     //Default: 0.02<br>Highlight expensive physics objects strength, no need since expensive obj is disabled by default
+        r_citadel_shadowdb                        "256"   //Default: 2048<br>
+        r_citadel_shadow_quality                  "0"     //Default: 1<br>Shadow Quality
+        r_effects_bloom                           "false" //Default: true<br>
+        r_citadel_glow_health_bars                "false" //default true
+        r_citadel_enable_pano_world_blur          "true"  //Default: true<br>Enable world-blur style
+        r_depth_of_field                          "false" //default true
+        r_directional_lightmaps                   "false" //default true
+        r_citadel_distancefield_blur              "false" //Default: true<br>Enable/Disable distance field blur
+        r_citadel_distancefield_shadows           "false" //Default: true<br>
+        mat_max_lighting_complexity               "1"     //default 8
+        r_muzzleflashbrightness                   "0.01"  //default 0.4 idk if this does anything
+        r_particle_cables_render                  "true"  //default true break lash ult do not disable
+        r_postprocess_enable                      "false" //default true
+        lb_dynamic_shadow_resolution              "false" //default true
+        cl_glow_brightness                        "0"     //default 1
+        r_distancefield_enable                    "false" //default true Graphics/Enable Distance Field rendering
+        lb_enable_sunlight                        "false" //Default: true<br>SceneSystem/LightBinner/Enable Sunlight
+        citadel_trooper_friendly_glow_disabled    "true"  //was false doesnt work btw
+        cl_input_enable_raw_keyboard              "true"  //Default: false<br>Enable raw keyboard input
+        r_environment_map_roughness_range         "0.01"  //Default: 0.2 0.3<br>Fade region for sampling environment maps on lightmapped nonmetals. Smoother values than the first param sample envmaps. Rougher values than the second sample only lightmap SH. r_environment_map_roughness_range 1 1 to always sample envmaps for comparison. BASICALLY TURN OFF REFLECTIONS ON MAP I THINK
+        lb_cubemap_normalization_max              "1"     //Default: 32<br>
+        lb_cubemap_normalization_roughness_begin  "0.01"  //Default: 0.1<br>
+        thumper_use_plane_reflection              "false" //Default: true<br>
+        cl_ragdoll_default_scale                  "0"     //default 1 doesnt matter since ragdoll disabled
+        sc_instanced_mesh_mesh_shader             "false" //default true Toggles mesh shader rendering for instanced meshes
+
+        r_citadel_disable_npr_lighting "false" //True to make lighting ass, save you just a bit more fps
+
+        r_fullscreen_gamma "1.4" //recommended ppl to use this to make the game brighter, bigge number = darker (use again in console if game not bright, only work in fullscreen exclusive, try 2.1 then 1.4 to make it work i have 2 keys binded for this)
+
+        mat_colorcorrection           "0"
+        panorama_allow_transitions    "false" //default true turns off UI anim (shop,etc)
+        panorama_disable_blur         "true"  //disable ui blur
+        // r_citadel_upscaling        "0"     //Default: 4<br> doesnt do anything
+        citadel_trooper_glow_disabled "true"
+
+        lb_mixed_shadows                     "false"
+        r_arealights                         "false" //was true
+        r_citadel_antialiasing               "0"     //default 1
+        r_character_decal_monitor_render_res "64"    //Default: 512<br>
+        r_citadel_depthoffield_enable        "false"
+        mat_viewportscale                    "0.01"  //was 1 this controls LOD on everything except trees and bushes (good) for some reason
+        fx_drawmetalspark                    "false" //Default: true<br>Draw metal spark effects.
+        r_mapextents                         "4500"  //Default: 16384<br>Set the max dimension for the map.  This determines the far clipping plane, set to higher number if no like popping building
+        r_citadel_npr_force_solid_outline    "true"  //default false
+        // r_dopixelvisibility               "false" //default true enables or disables pixel visibility calculations, which can affect performance and visibility checks within the game.
+        citadel_player_outline_enemies       "false" //turn off enemy outline DOES NOT BREAK BACKSTABBER OR PING THRU WALL
+        sc_screen_size_lod_scale_override    "0.001" //was -1
+        mat_colorcorrection                  "0"
+        r_farz                               "6000" //default -1 far clipping plane, same as r_mapextents but this affect another thing that i dont understand yet, it gives fps though
+        cl_disable_ragdolls                  "true"
+        // citadel_player_glow_disabled      "true"  //default false, breaks backstabber
+        citadel_trooper_outline_enabled      "false" //turn off trooper outline
+
+        citadel_hideout_enable_testing_tools "true" //default false doesnt work
+
+        // r_light_sensitivity_mode "true"
+
+        phys_cull_internal_mesh_contacts "true" //default false
+        citadel_use_pvs_for_players      "true" //default false, culls players when out of view
+        // r_particle_max_texture_layers "3"    //was -1
+
+        r_citadel_distancefield_down_sample "6" //default 1
+
+        ai_gather_conditions_async "true" //default false
+        enable_priority_boost      "1"
+
+        update_voices_low_priority             "true" //default false
+        animgraph_enable_parallel_preupdate    "true" //default false Enables parallel processing for the pre-update phase of animation graphs, helping spread the load across more CPU cores
+        // anim_decode_forcewritealltransforms "true" //Default: false<br>Force BatchAnimationDecode to write transformations for all bones
+        // net_skip_redundant_change_callbacks "true" //default false im p sure this keep pulling up report screen for some reason
+        // animgraph_footlock_enabled          "false"
+        r_morphing_enabled                     "false"
+        r_smooth_morph_normals                 "0"
+
+        // animgraph_slowdownonslopes_enabled        "false"
+        cl_simulate_dormant_entities                 "false"
+        // engine_allow_multiple_simulates_per_frame "false" //default false not sure about this one so dont change it
+
+        // animgraph_enable_parallel_op_evaluation "true" //default false
+        // animgraph_enable_parallel_preupdate     "true" //false
+        ai_lod_auto_enabled                        "true" //default 0, idk about this
+        ai_use_async_ragdoll_fixup                 "true" //doesnt really need tbh since ragdoll is disabled
+        cl_phys_networked_start_sleep              "true" //try on and off, this is probably what causing result screen to pop up when idling
+        func_break_max_pieces                      "1"    //default 15
+
+        r_light_flickering_enabled            "false"
+        sc_clutter_density_none_size          "0.1"   //Default 0.0035
+        // r_draw_overlays                    "false" //removes the walker line on the ground too, do not recommend
+        snd_mixahead                          "0.05"  //set to 0.001 if have good CPU, 0.05 adds 50ms to audio mixing thus save CPU perf, should not be perceiveable by any human.
+        // cl_interp                          "0.033" //i would not play with interps
+        r_draw_particle_children_with_parents "0"
+
+        r_ssao_blur                       "0"
+        r_decals_max_on_deformables       "0"
+        r_particle_cables_render_meshlets "false" //default true
+        lb_csm_cross_fade_override        "0"
+        lb_csm_distance_fade_override     "0"
+        sc_enable_discard                 "true" //default true
+        sc_clutter_density_full_size      "0.5"
+        sc_clutter_density_none_size      "0.1"
+        r_decals_overlap_threshold        "5"
+        r_flashlightbrightness            "0"
+        r_flashlightfar                   "0"
+        r_flashlightshadowatten           "0"
+        sc_allow_dithered_lod             "0"
+        sc_dithered_lod_transition_amt    "0"
+
+        lb_dynamic_shadow_penumbra               "false" //default true
+        phys_multithreading_enabled              "1"     //default true, alr enabled no need to include ngl
+        // engine_allow_multiple_ticks_per_frame "0"     //remove
+        nav_pathfind_multithread                 "1"     //default false test 1 and 0, moves npc pathing to separate thread
+
+        // cl_predict_after_every_createmove "0" // test 1 0
+        // cl_predictioncopy_runs            "0" //put to 1 if character vibrates
+        r_particle_batch_collections         "1"
+
+        r_texture_stream_resolution_bias            "0.01"
+        // lb_enable_envmaps                        "0" //REMOVE THIS DO NOT CHANGE THIS VALUE CUZ EVERYTHING IS GONNA BE BLACK
+        lb_enable_baked_shadows                     "1"
+        r_world_wind_frequency_grass                "0"
+        r_world_wind_frequency_trees                "0"
+        mat_tonemap_bloom_scale                     "0"
+        // mat_disable_dynamic_shader_compile       "1"
+        lb_barnlight_shadow_use_precomputed_vis     "0"
+        r_low_latency                               "1" //Force enabling this for kaiz only, Default: 1<br>NVIDIA Low Latency/AMD Anti-Lag 2 (0 = off, 1 = on, 2 = NV-only, on + boost)
+        mesh_calculate_curvature_smooth_pass_count  "0"
+        panorama_transition_time_factor             "2"     //faster transition for the stuff that doesnt use animation
+        phys_dynamic_scaling                        "false" //default true
+        phys_expensive_shape_threshold              "100"   //was 6
+        sc_max_framebuffer_copies_per_layer         "0"     //no idea what this does ngl
+        r_strip_invisible_during_sceneobject_update "1"     //Default: false<br>
+        // fs_async_threads                         "17"    //was 8
+        props_break_apply_radial_forces             "false"
+        // panorama_min_comp_layer_cache_cost       "256"
+        r_citadel_depth_prepass_dynamic_objects     "0"
+        particle_cluster_use_collision_hulls        "0"
+        citadel_unit_status_old_update_rate         "15"
+        r_pipeline_stats_use_flush_api              "0"
+        sc_instanced_mesh_opaque_fade               "0"
+        g_ragdoll_important_maxcount                "1"
+        g_ragdoll_maxcount                          "1"
+        r_texture_stream_max_resolution             "128"
+        r_texture_nonstreaming_load                 "1"
+        // r_indirectlighting                       "false"
+        csm_max_num_cascades_override               "2"
+        r_hair_indirect_transmittance               "false"
+        // r_lightmap_bicubic_filtering             "false"
+        r_drawdecals                                "false" //defaul true
+        minimap_update_rate_hz                      "30"
+        ai_think_interval                           "0.3"
+
+        ai_async_queue_max_jobs                       "1" //was 8
+        ai_think_interval_lod_med                     "0.4"
+        ai_think_interval_lod_low                     "1"
+        ai_gather_conditions_async                    "true"
+        ai_foot_sweep_enable                          "false"
+        wind_system_temporal_smoothing                "false"
+        wind_system_default_resolution_xy             "64"
+        lb_precomputed_shadowmap_enable               "0"
+        lb_shadow_map_cull_empty_mixed                "true"
+        r_citadel_fog_quality                         "0"
+        r_citadel_gpu_culling_shadows                 "1" //test, was 0
+        r_hair_shadowtile                             "false"
+        vis_sunlight_enable                           "0"
+        snd_use_baked_occlusion                       "1"
+        citadel_per_weapon_per_surface_impact_effects "false"
+
+        r_particle_model_per_thread_count "64"
+        r_limit_particle_job_duration     "1"
+
+        r_citadel_selection_outline2_offset         "2"
+        r_citadel_selection_outline2_alpha          "255"
+        r_citadel_selection_outline2_width          "10"
+        battery_saver                               "false"
+        citadel_in_world_item_panel_dpi             "0.5"
+        // citadel_minimap_use_canvas_for_neutrals  "0"
+        // citadel_minimap_use_canvas_for_shop      "0"
+        citadel_npc_disable_floor_point_caching     "false"
+        citadel_npc_force_animate_every_tick        "false"
+        cl_batch_entity_list_ops_during_latch       "1"
+        cl_bone_cache_optimization                  "1"
+        cl_particle_batch_mode                      "1"
+        // cl_particle_max_count                    "1" //max # of particle? doesnt seem to work idk
+        cl_phys_sleep_enable                        "1"
+        csm_cascade0_override_dist                  "0"
+        csm_cascade1_override_dist                  "0"
+        csm_cascade2_override_dist                  "0"
+        csm_cascade3_override_dist                  "0"
+        csm_max_dist_between_caster_and_receiver    "0"
+        csm_max_visible_dist                        "0"
+        csm_res_override_0                          "1"
+        csm_res_override_1                          "1"
+        csm_res_override_2                          "1"
+        csm_res_override_3                          "1"
+        csm_viewmodel_shadows                       "false"
+        dsp_slow_cpu                                "1"
+        engine_low_latency_sleep_after_client_tick  "1"
+        fog_enable                                  "0" //doesnt work anymore sadly
+        fog_enableskybox                            "0"
+        m_rawinput                                  "1" //doesnt seem to exist in deadlock yet
+        mm_idle_enabled                             "false"
+        nav_obstruction_async_update                "true"
+        r_aoproxy_cull_dist                         "0.01"
+        r_lightmap_size                             "1"
+        r_post_bloom                                "0"
+        r_ssao_strength                             "0" //alr disabled ssao above shouldnt matter
+        sc_disable_baked_lighting                   "false"
+        sc_force_materials_batchable                "true"
+        snd_occlusion_bounces                       "0" //try on and off
+        anim_disable                                "true"
+        r_citadel_gpu_culling_two_pass              "0"
+        r_late_particle_job_sync                    "1"
+        // snd_soundmixer_version                   "1"
+        // thread_pool_option                       "6"
+        r_flush_on_pooled_ib_resize                 "false"
+        r_texture_stream_throttle_count_over_budget "0"
+        // r_update_particles_on_render_only_frames "1"
+
+        cl_skel_constraints_enable            "0"
+        ik_enable                             "0"
+        // panorama_disable_draw_text_shadow  "1"
+        panorama_disable_descendant_filtering "true"
+
+        net_use_packet_compression   "false"
+        cl_pred_optimize             "true"
+        cl_pred_parallel_postnetwork "true"
+
+        sc_instanced_mesh_gpu_culling            "true"
+        sc_aggregate_gpu_culling                 "true"
+        // sc_disable_procedural_layer_rendering "true"
+        cl_skip_update_animations                "0" // Puts neutrals in the ground
+
+        // r_skinning_enabled            "0" //turns everything into tpose
+        cl_phys_animated_hierarchy       "false"
+        phys_continuous_kinematic_update "0"
+
+        snd_disable_mixer_duck "1"
+        lb_enable_newsum       "0"
+
+        lb_csm_draw_alpha_tested            "0"  // Stops calculating shadow alpha on fences/leaves
+        lb_shadow_texture_width_override    "16" // Shrinks the global shadow atlas to 16 pixels
+        lb_shadow_texture_height_override   "16" // Shrinks the global shadow atlas to 16 pixels
+        sparseshadowtree_disable_add_layers "1"  // Completely breaks Sparse Shadow Tree layering
+        mat_slopescaledepthbias_shadowmap   "0"  // Disables shadow depth bias math
+        mat_depthbias_shadowmap             "0"  // Disables shadow depth bias math
+        sc_allow_dynamic_constant_batching  "1"
+
+        sc_disable_culling_boxes      "1" // Skips calculating bounding boxes for culling
+        // sc_disable_world_materials "1" // Turns the entire map gray (strips all materials from the world)
+        // r_draw_instances           "0" // Deletes small props and details from the map entirely
+        r_flashlightambient           "0" // Disables ambient lighting math on flashlights/muzzle flashes
+        r_flashlightconstant          "0" // Disables constant lighting math
+
+        sc_allow_precomputed_vismembers         "1"
+        sc_barnlight_enable_precomputed_vis     "1"
+        lb_barnlight_shadow_use_precomputed_vis "1"
+        sc_force_single_display_list_per_layer  "1"
+        sc_aggregate_gpu_occlusion_culling      "1"
+        sc_aggregate_gpu_vis_culling            "1"
+
+        citadel_damage_indicator_radius  "1"
+        citadel_damage_indicator_height  "10"
+        citadel_damage_indicator_width   "10"
+        citadel_damage_text_lifetime     "0.01"
+        citadel_damage_text_lifetime_new "0.1"
+        r_threaded_particles             "1"
+
+        panorama_enable_secondary_layout_pass     "0" // Skips the secondary CSS layout check (drastically reduces UI calculation time)
+        panorama_draw_text_fast_path              "1" // Forces text rendering through a hardware fast-path
+        panorama_draw_text_fast_path_text_shadow  "1" // Forces text shadows through a hardware fast-path
+        panorama_hsbc_through_fast_path           "1" // Forces UI hue/saturation/brightness changes through a fast-path
+        panorama_use_backbuffer_directly          "1" // Skips copying the UI buffer to memory and writes directly to the backbuffer
+        panorama_script_cache_enabled             "1" // Aggressively caches UI Javascript to prevent mid-game recompilation
+        citadel_unit_status_hide_names            "1" // Removes player names from health bars (text rendering is heavy).
+        citadel_hud_objective_health_idle_timeout "0" // Boss/Tower health bars vanish the millisecond they stop taking damage.
+        citadel_camera_parrot_smoothing_rate      "0" // Stops the camera from running math to "smooth" itself back into place after hitting a wall.
+        // steam_inputhandler_enabled             "0" // Completely disables Steam Input API polling. Huge for 1% lows if you only use Keyboard/Mouse.
+
+        panorama_clear_frames_on_device_restore "0"
+
+
+
+
+        rate
+        {
+            min     "98304"
+            default "786432"
+            max     "1000000"
+        }
+        sv_minrate                   "98304"
+        sv_maxunlag                  "0.500"
+        sv_maxunlag_player           "0.200"
+        sv_lagcomp_filterbyviewangle "false"
+
+        // Spew warning when adding/removing classes to/from the top of the hierarchy
+        panorama_classes_perf_warning_threshold_ms "0.75"
+
+        // Panorama - enable minidumps on JS exceptions
+        panorama_js_minidumps "1"
+        // Enable the render target cache optimization.
+        panorama_disable_render_target_cache "0"
+
+        // Enable the composition layer optimization
+        panorama_skip_composition_layer_content_paint "1"
+
+        // too expensive (500MB+) to load this
+        snd_steamaudio_load_reverb_data  "0"
+        snd_steamaudio_load_pathing_data "0"
+
+        // Steam Audio project specific convars
+        snd_steamaudio_enable_custom_hrtf  "0"
+        snd_steamaudio_active_hrtf         "0"
+        snd_steamaudio_reverb_update_rate  "10.0"
+        snd_steamaudio_ir_duration         "1.0"
+        snd_steamaudio_enable_pathing      "0"
+        snd_steamaudio_invalid_path_length "0.0"
+        cl_disconnect_soundevent           "citadel.convar.stop_all_game_layer_soundevents"
+        snd_event_browser_default_stack    "citadel_default_3d"
+
+        // voip
+        voice_in_process "1"
+
+        // Sound debugging
+        snd_report_audio_nan "1"
+
+        // Audio system settings
+        snd_sos_max_event_base_depth "10"
+        sos_use_guid_filter          "1"
+
+        voice_always_sample_mic
+        {
+            version "2"
+            default "0"
+        }
+
+        reset_voice_on_input_stallout "0"
+        voice_input_stallout          "0.5"
+        cl_usesocketsforloopback      "1"
+        cl_poll_network_early         "0"
+
+        // Perf/Parallelism
+        iv_parallel_restore "1"
+
+        // For perf reasons, since we don't use source-based DSP:
+        disable_source_soundscape_trace "1"
+
+        // Networking - Induced latency (pred offset)
+        cl_tickpacket_recvmargin_desired              "5"   // 5 ms base, min. floor for protecting against thrashing the queue
+        cl_tickpacket_desired_queuelength             "0"   // 0 = attempt to always reach the queue's min floor
+        cl_async_usercmd_send_disabled_recvmargin_min "0.5" // Additional frame since we do not use the async usercmd send (potentially unneccessary)
+        cl_clock_buffer_ticks                         "1"
+        cl_interp_ratio                               "0"
+        cl_async_usercmd_send                         "false"
+
+        fps_max    "400"
+        fps_max_ui "120"
+
+        in_button_double_press_window "0.3"
+
+        // Convars that control spatialization of UI audio.
+        snd_ui_positional            "1"
+        snd_ui_spatialization_spread "2.4"
+
+        // sound volume rate change limiting
+        snd_envelope_rate                        "100.0"
+        snd_soundmixer_update_maximum_frame_rate "0"
+
+        //don't let people mess with speaker config settings.
+        speaker_config
+        {
+            min     "0"
+            default "0"
+            max     "2"
+        }
+
+        cq_buffer_bloat_msecs_max "120"
+
+        snd_soundmixer                   "Default_Mix"
+        cloth_filter_transform_stateless "0"
+
+        cl_joystick_enabled       "0"
+        panorama_joystick_enabled "0"
+
+        snd_event_browser_focus_events "true"
+
+        cl_max_particle_pvs_aabb_edge_length "100"
+
+        // Allow aggregation of particles (for perf)
+        cl_aggregate_particles "true"
+
+        citadel_enable_vdata_sound_preload "true"
+    }
+
+    Memory
+    {
+        EstimatedMaxCPUMemUsageMB "1"
+        EstimatedMinGPUMemUsageMB "1"
+
+        ShowInsufficientPageFileMessageBox      "1"
+        ShowLowAvailableVirtualMemoryMessageBox "1"
+    }
 }

--- a/piggy's config (comparatively outdated)/gameinfo.gi
+++ b/piggy's config (comparatively outdated)/gameinfo.gi
@@ -1,664 +1,661 @@
-"GameInfo"
+GameInfo
 {
-	game 		"citadel"
-	title 		"Citadel"
-	type		multiplayer_only
-	nomodels 1
-	nohimodel 1
-	nocrosshair 0
-	hidden_maps
-	{
-		"test_speakers"			1
-		"test_hardware"			1
-	}
-	nodegraph 0
-	perfwizard 0
-	tonemapping 0 
-	GameData	"citadel.fgd"
-	
-	Localize
-	{
-		DuplicateTokensAssert	1
-	}
-
-	SupportedLanguages
-	{
-		"brazilian" "3"
-		"czech" "3"
-		"english" "3"
-		"french" "3"
-		"german" "3"
-		"italian" "3"
-		"indonesian" "3"
-		"japanese" "3"
-		"koreana" "3"
-		"latam" "3"
-		"polish" "3"
-		"russian" "3"
-		"schinese" "3"
-		"spanish" "3"
-		"thai" "3"
-		"turkish" "3"
-		"ukrainian" "3"
-	}
-	
-	FileSystem
-	{	
-		//
-		// The code that loads this file automatically does a few things here:
-		//
-		// 1. For each "Game" search path, it adds a "GameBin" path, in <dir>\bin
-		// 2. For each "Game" search path, it adds another "Game" path in front of it with _<language> at the end.
-		//    For example: c:\hl2\cstrike on a french machine would get a c:\hl2\cstrike_french path added to it.
-		// 3. If no "Mod" key, for the first "Game" search path, it adds a search path called "MOD".
-		// 4. If no "Write" key, for the first "Game" search path, it adds a search path called "DEFAULT_WRITE_PATH".
-		//
-
-		//
-		// Search paths are relative to the exe directory\..\
-		//
-		SearchPaths
-		{
-			// These are optional language paths. They must be mounted first, which is why there are first in the list.
-			// *LANGUAGE* will be replaced with the actual language name. If not running a specific language, these paths will not be mounted
-			Game_Language		citadel_*LANGUAGE*
-
-			// These are optional low-violence paths. They will only get mounted if you're in a low-violence mode.
-			Game_LowViolence	citadel_lv
-
-
-            Game                citadel/addons
-            Mod                 citadel
-            Write               citadel          
-            Game                citadel
-            Mod                 core
-            Write               core
-            Game                core    
-		}
-	}
-	
-	MaterialSystem2
-	{
-		RenderModes
-		{
-			game Default
-			game Forward
-			game Deferred
-			game Outline
-			game Depth
-			game FrontDepth
-
-			dev ToolsVis // Visualization modes for all shaders (lighting only, normal maps only, etc.)
-			dev ToolsWireframe // This should use the ToolsVis mode above instead of being its own mode\
-
-			tools ToolsUtil // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
-		}
-	}
-
-	MaterialEditor
-	{
-		"DefaultShader" "environment_texture_set"
-	}
-
-	NetworkSystem
-	{
-		BetaUniverse
-		{
-			FakeLag			40
-			FakeLoss		.1
-			//FakeReorderPct 0.05
-			//FakeReorderDelay 10
-			//FakeJitter "low"
-			// Turning off fake jitter for now while I work on making the CQ totally solid
-			FakeReorderPct 0
-			FakeReorderDelay 0
-			FakeJitter "off"
-		}
-
-		"SkipRedundantChangeCallbacks"	"1"
-	}
-
-	RenderSystem
-	{
-		IndexBufferPoolSizeMB 32
-		UseReverseDepth 1
-		Use32BitDepthBuffer 0
-		Use32BitDepthBufferWithoutStencil 0
-		SwapChainSampleableDepth 1
-		VulkanMutableSwapchain 1
-		"LowLatency"								"1"
-		"VulkanOnly"								"1"	[ $LINUX || $OSX ] // No OpenGL or D3D9/11 fallback on Linux or OSX, only Vulkan is supported.
-		"VulkanRequireSubgroupWaveOpSupport"		"1"	[ !$OSX ]
-		"VulkanRequireDescriptorIndexing"			"1"	[ !$OSX ]
-		"VulkanSteamShaderCache" "1"
-		"VulkanSteamAppShaderCache" "1"
-		"VulkanSteamDownloadedShaderCache" "1"
-		"VulkanAdditionalShaderCache" "vulkan_shader_cache.foz"
-		"VulkanStagingPMBSizeLimitMB" "384"
-		"GraphicsPipelineLibrary"	"1"
-		"VulkanOnlyTestProbability" "0"
-		"VulkanDefrag"				"1"
-		"MinStreamingPoolSizeMB"	"1024"
-		"MinStreamingPoolSizeMBTools" "2048"
-	}
-
-	NVNGX
-	{
-		AppID 103371621
-		SupportsDLSS 1
-	}
-
-	Engine2
-	{
-		HasModAppSystems 1
-		Capable64Bit 1
-		URLName citadel
-		RenderingPipeline
-		{
-			SupportsMSAA 0
-			DistanceField 1
-		}
-		PauseSinglePlayerOnGameOverlay 1
-		DefensiveConCommands 1
-		DisableLoadingPlaque 1
-	}
-
-	ContentBuilder
-	{
-		ResourceCompilerDirectXUsesWARP "0"
-	}
-
-	SoundSystem
-	{
-		SteamAudioEnabled            "1"
-		WaveDataCacheSizeMB          "256"
-		"UsePlatTime"            "1"
-	}
-	Sounds
-	{
-		HierarchicalEncodingFiles	 "1"
-	}
-
-	ToolsEnvironment
-	{
-		"Engine"	"Source 2"
-		"ToolsDir"	"../sdktools"	// NOTE: Default Tools path. This is relative to the mod path.
-	}
-	
-	pulse
-	{
-		"pulse_enabled"					"1"
-	}
-
-	Hammer
-	{
-		"fgd"					"citadel.fgd"	// NOTE: This is relative to the 'game' path.
-		"GameFeatureSet"		"Citadel"
-		"DefaultSolidEntity"	"trigger_multiple"
-		"DefaultPointEntity"	"info_player_start"
-		"NavMarkupEntity"		"func_nav_markup"
-		"OverlayBoxSize"			"8"
-		"TileMeshesEnabled"			"1"
-		"RenderMode"				"ToolsVis"
-		"CreateRenderClusters"		"1"
-		"DefaultMinDrawVolumeSize"	"2048"
-		"DefaultMinTrianglesPerCluster"	"16384"
-		"TileGridSupportsBlendHeight"	"1"
-		"TileGridBlendDefaultColor"	"0 255 0"
-		"LoadScriptEntities" "0"
-		"UsesBakedLighting" "1"
-		"UseAnalyticGrid" "0"
-		"SupportsDisplacementMapping" "0"
-		"SteamAudioEnabled"				"1"
-		"LatticeDeformerEnabled"		"1"
-		"ShadowAtlasWidth" "16384"
-		"ShadowAtlasHeight" "16384"
-		"TimeSlicedShadowMapRendering" "1"
-	}
-
-	SoundTool
-	{
-		"DefaultSoundEventType" "src1_3d"
-
-		SoundEventBaseOptions
-		{
-			"Base.Announcer.VO.2d" ""
-			"Base.World.VO.Emitter.3d" ""
-			"Base.Hero.VO.Ping.2d" ""
-			"Base.Hero.VO.2d" ""
-			"Base.Hero.VO.3d" ""
-			"Base.Hero.VO.Ability.3d" ""
-			"Base.Hero.VO.Ultimate.3d" ""
-			"Base.Hero.VO.Dash.3d" ""
-			"Base.Hero.VO.Effort.3d" ""
-			"Base.Hero.VO.Pain.3d" ""
-			"Base.Hero.VO.Melee.3d" ""
-			"Base.Hero.VO.Death.3d" ""
-		}
-	}
-
-	RenderPipelineAliases
-	{
-	}
-
-	ResourceCompiler
-	{
-		// Overrides of the default builders as specified in code, this controls which map builder steps
-		// will be run when resource compiler is run for a map without specifiying any specific map builder
-		// steps. Additionally this controls which builders are displayed in the hammer build dialog.
-		DefaultMapBuilders
-		{
-			"bakedlighting"	"1"	// Enable lightmapping during compile time		
-			"envmap"	"0" // turned off since it currently causes an assert and doesn't work due to some build issue
-			"nav"		"1"	// Generate nav mesh data
-		}
-
-		MeshCompiler
-		{
-			OptimizeForMeshlets 1
-			TrianglesPerMeshlet 64	// Maximum valid value currently is 126
-			UseMikkTSpace 1
-			EncodeVertexBuffer 1
-            EncodeVertexBufferVersion 1
-            EncodeVertexBufferLevel 3
-			EncodeIndexBuffer 1
-			SplitDepthStream 1
-		}
-
-		WorldRendererBuilder
-		{
-			VisibilityGuidedMeshClustering      "1"
-			MinimumTrianglesPerClusteredMesh    "8192"
-			MinimumVerticesPerClusteredMesh     "8192"
-			MinimumVolumePerClusteredMesh       "8192"       // ~20x20x20 cube
-			MaxPrecomputedVisClusterMembership  "96"
-			MaxCullingBoundsGroups              "128"
-			UseAggregateInstances				"1"
-			AggregateInstancingMeshlets			"1"
-			BakePropsWithExtraVertexStreams		"1"
-		}
-
-		BakedLighting
-		{
-			Version 4
-			ImportanceVolumeTransitionRegion 512            // distance we transition from high to low resolution charts 
-			LightmapChannels
-			{
-				direct_light_shadows 1
-				debug_chart_color 1
-				directional_irradiance_sh2_dc 1
-				
-				directional_irradiance_sh2_r
-				{
-					CompressedFormat DXT1
-				}
-				
-				directional_irradiance_sh2_g
-				{
-					CompressedFormat DXT1
-				}
-				
-				directional_irradiance_sh2_b
-				{
-					CompressedFormat DXT1
-				}
-			}
-			LightmapGutterSize 2 // For bicubic filtering
-			UseStaticLightProbes 0
-			LPVAtlas 1
-			BC6HHueShiftFixup 0 // Causes more artifacts than it solves atm
-			Repack2 1
-		}
-
-		SteamAudio
-		{
-			ReverbDefaults
-			{
-				GridSpacing			"3.0"
-				HeightAboveFloor	"1.5"
-				RebakeOption		"0"						// 0: cleanup, 1: manual, 2: auto
-				NumRays				"32768"
-				NumBounces			"64"
-				IRDuration			"1.0"
-				AmbisonicsOrder		"1"
-			}
-			PathingDefaults
-			{
-				GridSpacing			"3.0"
-				HeightAboveFloor	"1.5"
-				RebakeOption		"0"						// 0: cleanup, 1: manual, 2: auto
-				NumVisSamples		"1"
-				ProbeVisRadius		"0"
-				ProbeVisThreshold	"0.1"
-				ProbeVisPathRange	"1000.0"
-			}
-		}
-		SoundStackScripts
-		{
-			CompileStacksStrict "1"
-		}
-		VisBuilder
-		{
-			MaxVisClusters "4096"
-			PreMergeOpenSpaceDistanceThreshold "128.0"
-			PreMergeOpenSpaceMaxDimension "2048.0"
-			PreMergeOpenSpaceMaxRatio "8.0"
-			PreMergeSmallRegionsSizeThreshold "20.0"
-		}
-
-		VDataLocalization
-		{
-			GameOutputPath	"resource/localization/citadel_vdata"
-			TokenPrefix		"Citadel_VData_"
-		}
-	}
-
-	Source1Import
-	{
-		// this is just copied from the left4dead3 gameinfo.gi
-		"forcevtxfileupconvert" 1
-	}
-
-	WorldRenderer
-	{
-		EnvironmentMaps					1
-		EnvironmentMapFaceSize			256
-		EnvironmentMapRenderSize		1024
-		EnvironmentMapFormat			BC6H
-		EnvironmentMapPreviewFormat 		BC6H
-		EnvironmentMapColorSpace		linear
-		EnvironmentMapMipProcessor		GGXCubeMapBlur
-		// Build cubemaps into a cube array instead of individual cubemaps.
-		"EnvironmentMapUseCubeArray" 	1
-		"EnvironmentMapCacheSizeTools"  300
-		BindlessSceneObjectDesc			CitadelBindlessDesc
-		GrassCastsShadows				1
-	}
-
-	SceneSystem
-	{
-		GpuLightBinner 1
-		FogCachedShadowAtlasWidth 2048
-		FogCachedShadowAtlasHeight 2048
-		FogCachedShadowTileSize 128
-		GpuLightBinnerSunLightFastPath 1
-		CSMCascadeResolution 2048
-		SunLightManagerCount 0
-		SunLightManagerCountTools 0
-		DefaultShadowTextureWidth 6144
-		DefaultShadowTextureHeight 6144
-		DynamicShadowResolution 1
-
-		TransformTextureRowCount	1024
-		TransformTextureRowCountToolsMode 6144
-		SunLightMaxCascadeSize		4
-		SunLightShadowRenderMode	Depth
-		LayerBatchThresholdFullsort 20
-		NonTexturedGradientFog		1
-		// Temp till I can add support in citadel shaders
-		DisableLateAllocatedTransformBuffer 1
-		MinimumLateAllocatedVertexCacheBufferSizeMB 64
-		CubemapFog 1
-		VolumetricFog 1
-		FrameBufferCopyFormat R11G11B10F
-		Tonemapping 0
-		
-		WellKnownLightCookies
-		{
-			"blank" "materials/effects/lightcookies/blank.vtex"
-			"flashlight" "materials/effects/lightcookies/flashlight.vtex"
-		}
-
-		ComputeShaderSkinning 1
-	}
-
-	NavSystem
-	{
-		"NavTileSize" "128.0"
-		"NavCellSize" "1.5"
-		"NavCellHeight" "2.0"
-
-		// Hull definitions live in scripts/nav_hulls.vdata
-		// Preset definitions live in scripts/nav_hulls_presets.vdata
-		"NavHullsPreset" "default"
-
-		"NavRegionMinSize" "8"
-		"NavRegionMergeSize" "20"
-		"NavEdgeMaxLen" "1200"
-		"NavEdgeMaxError" "51.0"
-		"NavVertsPerPoly" "4"
-		"NavDetailSampleDistance" "120.0"
-		"NavDetailSampleMaxError" "2.0"
-		"NavSmallAreaOnEdgeRemovalSize" "81.0"
-	}
-
-	AnimationSystem
-	{
-		"DisableServerInterpCompensation"	"1"
-		"DisableAnimationScript" 	"1"
-		"ServerPoseRecipeHistorySize"	"60"
-		"ClientPoseRecipeHistorySize"	"60"
-
-	}
-
-	ModelDoc
-	{
-		"models_gamedata"			"models_gamedata.fgd"
-		"features"					"animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
-	}
-
-	Particles
-	{
-		"EnableParticleShaderFeatureBranching"	"1"
-		"Float16HDRBackBuffer" "1"
-		"PET_SupportFadingOpaqueModels" "1"
-		"Features" "non_homogenous_forward_layer_only"
-	}
-
-	ConVars
-	{
-
-m_rawinput 1                          // Uses raw mouse input, better aim consistency, no FPS cost
-cl_input_enable_raw_keyboard 1        // Uses raw keyboard input, slightly lower input latency
-m_filter 0                            // Disables mouse smoothing, improves responsiveness
- 
-// -------------Delete this part if you care about lighting --------------------------
- 
-r_directlighting 0                    // Disables direct lighting, large FPS gain
-r_rendersun 0                         // Disables sun lighting, reduces GPU load
-lb_enable_shadow_casting 0            // Turns off shadow casting, huge FPS boost
-lb_enable_dynamic_lights 0            // Disables dynamic lights, fewer draw calls
-lb_enable_lights 1                    // Disables static lights, saves GPU time
-lb_enable_stationary_lights 0         // Disables stationary lights, extra lighting savings
- 
-// -----------------------------------------------------------------------------------
- 
-lb_csm_draw_alpha_tested 0            // Disables alpha-tested shadows, reduces shadow passes	
-lb_csm_draw_translucent 0             // Disables translucent shadows, saves GPU
-csm_max_shadow_dist_override 0        // Forces shadows to stay disabled
-sc_disable_spotlight_shadows 1        // Disables spotlight shadows, very expensive feature
-sc_disable_shadow_materials 1         // Prevents special shadow materials from rendering
-cl_globallight_shadow_mode 0          // Forces lowest global shadow mode
-sparseshadowtree_enable_rendering 0   // Disables advanced sparse shadow system, big performance saver
-sparseshadowtree_disable_for_viewmodel 1 // Prevents viewmodel from using sparse shadows
-r_distancefield_enable 1              // Enables distance fields (needed for outlines, low cost)
-r_citadel_outlines 1                  // Enables enemy outlines, improves visibility
-r_citadel_distancefield_farfield_enable false // Disables long-range distance field effects
-r_citadel_npr_outlines_max_dist 600   // Limits outline distance to reduce unnecessary processing
-r_enable_volume_fog 0                 // Disables volumetric fog, large FPS gain
-r_enable_gradient_fog 0               // Disables gradient fog, saves GPU
-r_enable_cubemap_fog 0                // Disables cubemap fog, saves GPU
-volume_fog_intermediate_textures_hdr 0 // Disables HDR fog textures, reduces VRAM usage
-r_draw3dskybox 0                      // Disables 3D skybox, saves GPU time
-r_monitor_3dskybox 0                  // Prevents skybox monitoring updates
-r_world_wind_strength 0               // Disables wind effects, cosmetic only
-sv_waterdist 0                        // Reduces water rendering distance
-r_drawparticles 1                     // Keeps particles enabled (gameplay readability)
-r_particle_max_detail_level 0         // Lowest particle detail, better FPS
-r_particle_shadows 0                  // Disables particle shadows, high FPS gain
-r_particle_cables_cast_shadows 0      // Disables cable shadows, saves GPU
-r_RainParticleDensity 0               // Removes rain particles
-r_physics_particle_op_spawn_scale 0   // Prevents physics-based particle spawns
-r_particle_model_new8 0               // Disables newer particle models, saves performance
-cl_show_splashes 0                    // Disables water splashes, cosmetic only
-cl_particle_fallback_base 4           // Safe particle simplification threshold
-cl_particle_fallback_multiplier 4     // Controls how fast particles fall back to simple versions
-cloth_update 1                        // Keeps cloth enabled for model stability
-cloth_sim_on_tick 1                  // Updates cloth every tick, prevents jitter
-r_hair_ao 0                           // Disables hair ambient occlusion, cosmetic only
-cl_ragdoll_limit 1                    // Limits number of ragdolls, saves CPU
-ragdoll_parallel_pose_control 1       // Multithreaded ragdoll handling, better performance
-r_character_decal_resolution 1        // Low-resolution character decals
-r_drawmodeldecals 0                  // Disables model decals, saves GPU
-r_decals 16                           // Limits number of decals, improves FPS
-skeleton_instance_lod_optimization 1  // Enables model LOD optimization
-sc_clutter_enable 0                  // Disables clutter props, improves visibility & FPS
-r_size_cull_threshold 1.2             // Aggressive object culling to reduce draw calls
-r_drawropes 0                        // Disables rope rendering
-rope_collide 0                       // Disables rope collision physics
-rope_subdiv 0                        // Disables rope subdivisions
-rope_wind_dist 0                     // Disables rope wind simulation
-r_ropetranslucent 0                  // Disables translucent ropes
-r_grass_quality 0                    // Lowest grass quality
-r_grass_start_fade 0                 // Grass fades immediately
-r_grass_end_fade 0                   // Grass not rendered at distance
-panorama_disable_box_shadow 1         // Disables UI shadows, saves UI render cost
-panorama_max_overlay_fps 0            // Uncaps UI overlay FPS 
-panorama_max_fps 0                    // Uncaps UI FPS 
-rate 786432                          // Max network bandwidth allowed
-cl_predict 1                         // Enables client-side prediction
-cl_smooth 0                          // Disables view smoothing, reduces input latency
-mat_colorcorrection 1				// Colour stuff
-
-// End of piggy's config
-
-// ================ In Testing ================
-
-citadel_npc_force_animate_every_tick        "false"
-citadel_outer_radius_scaler                 "0.25"
-iv_parallel_restore                         "false"
-panorama_use_new_occlusion_invalidation     "false"
-r_decals_default_fade_duration                  "1"
-r_texture_budget_update_period                  "0.5"
-save_parallel                               "true"
-
-
-		"rate"
-		{
-			"min"		"98304"
-			"default"	"786432"
-			"max"		"1000000"
-		}
-		"sv_minrate"	"98304"
-		"sv_maxunlag"	"0.500"
-		"sv_maxunlag_player" "0.200"
-		"sv_lagcomp_filterbyviewangle" "false"
-
-		// Spew warning when adding/removing classes to/from the top of the hierarchy
-		"panorama_classes_perf_warning_threshold_ms" "0.75"
-
-		// Panorama - enable minidumps on JS exceptions
-		"panorama_js_minidumps" "1"
-		// Enable the render target cache optimization.
-		"panorama_disable_render_target_cache" "0"
-
-		// Enable the composition layer optimization
-		"panorama_skip_composition_layer_content_paint" "1"
-
-		// too expensive (500MB+) to load this
-		"snd_steamaudio_load_reverb_data" "0"
-		"snd_steamaudio_load_pathing_data" "0"
-
-		// Steam Audio project specific convars
-		"snd_steamaudio_enable_custom_hrtf"		"0"
-		"snd_steamaudio_active_hrtf"			"0"
-		"snd_steamaudio_reverb_update_rate"		"10.0"
-		"snd_steamaudio_ir_duration"			"1.0"
-		"snd_steamaudio_enable_pathing"			"0"
-		"snd_steamaudio_invalid_path_length"	"0.0"
-		"cl_disconnect_soundevent"				"citadel.convar.stop_all_game_layer_soundevents"
-		"snd_event_browser_default_stack"		"citadel_default_3d"
-		
-		// voip
-		"voice_in_process"			            "1"
-
-		// Sound debugging
-		"snd_report_audio_nan" "1"
-
-		// Audio system settings
-		"snd_sos_max_event_base_depth" "10"
-		"sos_use_guid_filter" "1"
-
-		"voice_always_sample_mic"               
-		{
-			"version"	"2"
-			"default"	"0"
-		}
-
-		"reset_voice_on_input_stallout"         "0"
-		"voice_input_stallout"                  "0.5"
-		"cl_usesocketsforloopback" "1"
-		"cl_poll_network_early" "0"
-
-		// For perf reasons, since we don't use source-based DSP:
-		"disable_source_soundscape_trace"       "1"
-		
-		// Networking - Induced latency (pred offset)
-		"cl_tickpacket_recvmargin_desired" "5" 					// 5 ms base, min. floor for protecting against thrashing the queue
-		"cl_tickpacket_desired_queuelength" "0"					// 0 = attempt to always reach the queue's min floor
-		"cl_async_usercmd_send_disabled_recvmargin_min" "0.5"	// Additional frame since we do not use the async usercmd send (potentially unneccessary)
-		"cl_clock_buffer_ticks"	"1"
-		"cl_interp_ratio" "0"
-		"cl_async_usercmd_send" "false"
-
-		"fps_max"		"400"
-		"fps_max_ui"	"120"
-
-		"in_button_double_press_window" "0.3"
-
-		// Convars that control spatialization of UI audio.
-		"snd_ui_positional"								"1"
-		"snd_ui_spatialization_spread"					"2.4"
-		
-		// sound volume rate change limiting
-		"snd_envelope_rate"								"100.0"
-		"snd_soundmixer_update_maximum_frame_rate" 		"0"
-
-		//don't let people mess with speaker config settings.
-		"speaker_config"
-		{
-			"min"		"0"
-			"default"	"0"
-			"max"		"2"
-		}
-
-		"cq_buffer_bloat_msecs_max" "120"
-
-		"snd_soundmixer"						"Default_Mix"
-		"cloth_filter_transform_stateless" "0"
-
-		"cl_joystick_enabled" "0"
-		"panorama_joystick_enabled" "0"
-
-		"snd_event_browser_focus_events" "true"
-
-		"cl_max_particle_pvs_aabb_edge_length" "100"
-		
-		// Allow aggregation of particles (for perf)
-		"cl_aggregate_particles" "true"
-		
-		"citadel_enable_vdata_sound_preload" "true"
-	}
-
-	Memory
-	{
-		"EstimatedMaxCPUMemUsageMB"	"1"
-		"EstimatedMinGPUMemUsageMB"	"1"
-
-		"ShowInsufficientPageFileMessageBox" "1"
-		"ShowLowAvailableVirtualMemoryMessageBox" "1"
-	}
+    game        "citadel"
+    title       "Citadel"
+    type        "multiplayer_only"
+    nomodels    "1"
+    nohimodel   "1"
+    nocrosshair "0"
+    hidden_maps
+    {
+        test_speakers "1"
+        test_hardware "1"
+    }
+    nodegraph   "0"
+    perfwizard  "0"
+    tonemapping "0"
+    GameData    "citadel.fgd"
+
+    Localize
+    {
+        DuplicateTokensAssert "1"
+    }
+
+    SupportedLanguages
+    {
+        brazilian  "3"
+        czech      "3"
+        english    "3"
+        french     "3"
+        german     "3"
+        italian    "3"
+        indonesian "3"
+        japanese   "3"
+        koreana    "3"
+        latam      "3"
+        polish     "3"
+        russian    "3"
+        schinese   "3"
+        spanish    "3"
+        thai       "3"
+        turkish    "3"
+        ukrainian  "3"
+    }
+
+    FileSystem
+    {
+        //
+        // The code that loads this file automatically does a few things here:
+        //
+        // 1. For each "Game" search path, it adds a "GameBin" path, in <dir>\bin
+        // 2. For each "Game" search path, it adds another "Game" path in front of it with _<language> at the end.
+        //    For example: c:\hl2\cstrike on a french machine would get a c:\hl2\cstrike_french path added to it.
+        // 3. If no "Mod" key, for the first "Game" search path, it adds a search path called "MOD".
+        // 4. If no "Write" key, for the first "Game" search path, it adds a search path called "DEFAULT_WRITE_PATH".
+        //
+
+        //
+        // Search paths are relative to the exe directory\..\
+        //
+        SearchPaths
+        {
+            // These are optional language paths. They must be mounted first, which is why there are first in the list.
+            // *LANGUAGE* will be replaced with the actual language name. If not running a specific language, these paths will not be mounted
+            Game_Language "citadel_*LANGUAGE*"
+
+            // These are optional low-violence paths. They will only get mounted if you're in a low-violence mode.
+            Game_LowViolence "citadel_lv"
+
+
+            Game  "citadel/addons"
+            Mod   "citadel"
+            Write "citadel"
+            Game  "citadel"
+            Mod   "core"
+            Write "core"
+            Game  "core"
+        }
+    }
+
+    MaterialSystem2
+    {
+        RenderModes
+        {
+            game "Default"
+            game "Forward"
+            game "Deferred"
+            game "Outline"
+            game "Depth"
+            game "FrontDepth"
+
+            dev "ToolsVis"       // Visualization modes for all shaders (lighting only, normal maps only, etc.)
+            dev "ToolsWireframe" // This should use the ToolsVis mode above instead of being its own mode\
+
+            tools "ToolsUtil" // Meant to be used to render tools sceneobjects that are mod-independent, like the origin grid
+        }
+    }
+
+    MaterialEditor
+    {
+        DefaultShader "environment_texture_set"
+    }
+
+    NetworkSystem
+    {
+        BetaUniverse
+        {
+            FakeLag             "40"
+            FakeLoss            ".1"
+            // FakeReorderPct   "0.05"
+            // FakeReorderDelay "10"
+            // FakeJitter       "low"
+            // Turning off fake jitter for now while I work on making the CQ totally solid
+            FakeReorderPct   "0"
+            FakeReorderDelay "0"
+            FakeJitter       "off"
+        }
+
+        SkipRedundantChangeCallbacks "1"
+    }
+
+    RenderSystem
+    {
+        IndexBufferPoolSizeMB              "32"
+        UseReverseDepth                    "1"
+        Use32BitDepthBuffer                "0"
+        Use32BitDepthBufferWithoutStencil  "0"
+        SwapChainSampleableDepth           "1"
+        VulkanMutableSwapchain             "1"
+        LowLatency                         "1"
+        VulkanOnly                         "\"1\" [ $LINUX || $OSX ]" // No OpenGL or D3D9/11 fallback on Linux or OSX, only Vulkan is supported.
+        VulkanRequireSubgroupWaveOpSupport "\"1\" [ !$OSX ]"
+        VulkanRequireDescriptorIndexing    "\"1\" [ !$OSX ]"
+        VulkanSteamShaderCache             "1"
+        VulkanSteamAppShaderCache          "1"
+        VulkanSteamDownloadedShaderCache   "1"
+        VulkanAdditionalShaderCache        "vulkan_shader_cache.foz"
+        VulkanStagingPMBSizeLimitMB        "384"
+        GraphicsPipelineLibrary            "1"
+        VulkanOnlyTestProbability          "0"
+        VulkanDefrag                       "1"
+        MinStreamingPoolSizeMB             "1024"
+        MinStreamingPoolSizeMBTools        "2048"
+    }
+
+    NVNGX
+    {
+        AppID        "103371621"
+        SupportsDLSS "1"
+    }
+
+    Engine2
+    {
+        HasModAppSystems "1"
+        Capable64Bit     "1"
+        URLName          "citadel"
+        RenderingPipeline
+        {
+            SupportsMSAA  "0"
+            DistanceField "1"
+        }
+        PauseSinglePlayerOnGameOverlay "1"
+        DefensiveConCommands           "1"
+        DisableLoadingPlaque           "1"
+    }
+
+    ContentBuilder
+    {
+        ResourceCompilerDirectXUsesWARP "0"
+    }
+
+    SoundSystem
+    {
+        SteamAudioEnabled   "1"
+        WaveDataCacheSizeMB "256"
+        UsePlatTime         "1"
+    }
+    Sounds
+    {
+        HierarchicalEncodingFiles "1"
+    }
+
+    ToolsEnvironment
+    {
+        Engine   "Source 2"
+        ToolsDir "../sdktools" // NOTE: Default Tools path. This is relative to the mod path.
+    }
+
+    pulse
+    {
+        pulse_enabled "1"
+    }
+
+    Hammer
+    {
+        fgd                           "citadel.fgd" // NOTE: This is relative to the 'game' path.
+        GameFeatureSet                "Citadel"
+        DefaultSolidEntity            "trigger_multiple"
+        DefaultPointEntity            "info_player_start"
+        NavMarkupEntity               "func_nav_markup"
+        OverlayBoxSize                "8"
+        TileMeshesEnabled             "1"
+        RenderMode                    "ToolsVis"
+        CreateRenderClusters          "1"
+        DefaultMinDrawVolumeSize      "2048"
+        DefaultMinTrianglesPerCluster "16384"
+        TileGridSupportsBlendHeight   "1"
+        TileGridBlendDefaultColor     "0 255 0"
+        LoadScriptEntities            "0"
+        UsesBakedLighting             "1"
+        UseAnalyticGrid               "0"
+        SupportsDisplacementMapping   "0"
+        SteamAudioEnabled             "1"
+        LatticeDeformerEnabled        "1"
+        ShadowAtlasWidth              "16384"
+        ShadowAtlasHeight             "16384"
+        TimeSlicedShadowMapRendering  "1"
+    }
+
+    SoundTool
+    {
+        DefaultSoundEventType "src1_3d"
+
+        SoundEventBaseOptions
+        {
+            Base.Announcer.VO.2d     ""
+            Base.World.VO.Emitter.3d ""
+            Base.Hero.VO.Ping.2d     ""
+            Base.Hero.VO.2d          ""
+            Base.Hero.VO.3d          ""
+            Base.Hero.VO.Ability.3d  ""
+            Base.Hero.VO.Ultimate.3d ""
+            Base.Hero.VO.Dash.3d     ""
+            Base.Hero.VO.Effort.3d   ""
+            Base.Hero.VO.Pain.3d     ""
+            Base.Hero.VO.Melee.3d    ""
+            Base.Hero.VO.Death.3d    ""
+        }
+    }
+
+    RenderPipelineAliases
+    {
+    }
+
+    ResourceCompiler
+    {
+        // Overrides of the default builders as specified in code, this controls which map builder steps
+        // will be run when resource compiler is run for a map without specifiying any specific map builder
+        // steps. Additionally this controls which builders are displayed in the hammer build dialog.
+        DefaultMapBuilders
+        {
+            bakedlighting "1" // Enable lightmapping during compile time
+            envmap        "0" // turned off since it currently causes an assert and doesn't work due to some build issue
+            nav           "1" // Generate nav mesh data
+        }
+
+        MeshCompiler
+        {
+            OptimizeForMeshlets       "1"
+            TrianglesPerMeshlet       "64" // Maximum valid value currently is 126
+            UseMikkTSpace             "1"
+            EncodeVertexBuffer        "1"
+            EncodeVertexBufferVersion "1"
+            EncodeVertexBufferLevel   "3"
+            EncodeIndexBuffer         "1"
+            SplitDepthStream          "1"
+        }
+
+        WorldRendererBuilder
+        {
+            VisibilityGuidedMeshClustering     "1"
+            MinimumTrianglesPerClusteredMesh   "8192"
+            MinimumVerticesPerClusteredMesh    "8192"
+            MinimumVolumePerClusteredMesh      "8192" // ~20x20x20 cube
+            MaxPrecomputedVisClusterMembership "96"
+            MaxCullingBoundsGroups             "128"
+            UseAggregateInstances              "1"
+            AggregateInstancingMeshlets        "1"
+            BakePropsWithExtraVertexStreams    "1"
+        }
+
+        BakedLighting
+        {
+            Version                          "4"
+            ImportanceVolumeTransitionRegion "512" // distance we transition from high to low resolution charts
+            LightmapChannels
+            {
+                direct_light_shadows          "1"
+                debug_chart_color             "1"
+                directional_irradiance_sh2_dc "1"
+
+                directional_irradiance_sh2_r
+                {
+                    CompressedFormat "DXT1"
+                }
+
+                directional_irradiance_sh2_g
+                {
+                    CompressedFormat "DXT1"
+                }
+
+                directional_irradiance_sh2_b
+                {
+                    CompressedFormat "DXT1"
+                }
+            }
+            LightmapGutterSize   "2" // For bicubic filtering
+            UseStaticLightProbes "0"
+            LPVAtlas             "1"
+            BC6HHueShiftFixup    "0" // Causes more artifacts than it solves atm
+            Repack2              "1"
+        }
+
+        SteamAudio
+        {
+            ReverbDefaults
+            {
+                GridSpacing      "3.0"
+                HeightAboveFloor "1.5"
+                RebakeOption     "0" // 0: cleanup, 1: manual, 2: auto
+                NumRays          "32768"
+                NumBounces       "64"
+                IRDuration       "1.0"
+                AmbisonicsOrder  "1"
+            }
+            PathingDefaults
+            {
+                GridSpacing       "3.0"
+                HeightAboveFloor  "1.5"
+                RebakeOption      "0" // 0: cleanup, 1: manual, 2: auto
+                NumVisSamples     "1"
+                ProbeVisRadius    "0"
+                ProbeVisThreshold "0.1"
+                ProbeVisPathRange "1000.0"
+            }
+        }
+        SoundStackScripts
+        {
+            CompileStacksStrict "1"
+        }
+        VisBuilder
+        {
+            MaxVisClusters                     "4096"
+            PreMergeOpenSpaceDistanceThreshold "128.0"
+            PreMergeOpenSpaceMaxDimension      "2048.0"
+            PreMergeOpenSpaceMaxRatio          "8.0"
+            PreMergeSmallRegionsSizeThreshold  "20.0"
+        }
+
+        VDataLocalization
+        {
+            GameOutputPath "resource/localization/citadel_vdata"
+            TokenPrefix    "Citadel_VData_"
+        }
+    }
+
+    Source1Import
+    {
+        // this is just copied from the left4dead3 gameinfo.gi
+        forcevtxfileupconvert "1"
+    }
+
+    WorldRenderer
+    {
+        EnvironmentMaps             "1"
+        EnvironmentMapFaceSize      "256"
+        EnvironmentMapRenderSize    "1024"
+        EnvironmentMapFormat        "BC6H"
+        EnvironmentMapPreviewFormat "BC6H"
+        EnvironmentMapColorSpace    "linear"
+        EnvironmentMapMipProcessor  "GGXCubeMapBlur"
+        // Build cubemaps into a cube array instead of individual cubemaps.
+        EnvironmentMapUseCubeArray   "1"
+        EnvironmentMapCacheSizeTools "300"
+        BindlessSceneObjectDesc      "CitadelBindlessDesc"
+        GrassCastsShadows            "1"
+    }
+
+    SceneSystem
+    {
+        GpuLightBinner                 "1"
+        FogCachedShadowAtlasWidth      "2048"
+        FogCachedShadowAtlasHeight     "2048"
+        FogCachedShadowTileSize        "128"
+        GpuLightBinnerSunLightFastPath "1"
+        CSMCascadeResolution           "2048"
+        SunLightManagerCount           "0"
+        SunLightManagerCountTools      "0"
+        DefaultShadowTextureWidth      "6144"
+        DefaultShadowTextureHeight     "6144"
+        DynamicShadowResolution        "1"
+
+        TransformTextureRowCount          "1024"
+        TransformTextureRowCountToolsMode "6144"
+        SunLightMaxCascadeSize            "4"
+        SunLightShadowRenderMode          "Depth"
+        LayerBatchThresholdFullsort       "20"
+        NonTexturedGradientFog            "1"
+        // Temp till I can add support in citadel shaders
+        DisableLateAllocatedTransformBuffer         "1"
+        MinimumLateAllocatedVertexCacheBufferSizeMB "64"
+        CubemapFog                                  "1"
+        VolumetricFog                               "1"
+        FrameBufferCopyFormat                       "R11G11B10F"
+        Tonemapping                                 "0"
+
+        WellKnownLightCookies
+        {
+            blank      "materials/effects/lightcookies/blank.vtex"
+            flashlight "materials/effects/lightcookies/flashlight.vtex"
+        }
+
+        ComputeShaderSkinning "1"
+    }
+
+    NavSystem
+    {
+        NavTileSize   "128.0"
+        NavCellSize   "1.5"
+        NavCellHeight "2.0"
+
+        // Hull definitions live in scripts/nav_hulls.vdata
+        // Preset definitions live in scripts/nav_hulls_presets.vdata
+        NavHullsPreset "default"
+
+        NavRegionMinSize              "8"
+        NavRegionMergeSize            "20"
+        NavEdgeMaxLen                 "1200"
+        NavEdgeMaxError               "51.0"
+        NavVertsPerPoly               "4"
+        NavDetailSampleDistance       "120.0"
+        NavDetailSampleMaxError       "2.0"
+        NavSmallAreaOnEdgeRemovalSize "81.0"
+    }
+
+    AnimationSystem
+    {
+        DisableServerInterpCompensation "1"
+        DisableAnimationScript          "1"
+        ServerPoseRecipeHistorySize     "60"
+        ClientPoseRecipeHistorySize     "60"
+
+    }
+
+    ModelDoc
+    {
+        models_gamedata "models_gamedata.fgd"
+        features        "animgraph;modelconfig;gamepreview;wireframe_backfaces;distancefield"
+    }
+
+    Particles
+    {
+        EnableParticleShaderFeatureBranching "1"
+        Float16HDRBackBuffer                 "1"
+        PET_SupportFadingOpaqueModels        "1"
+        Features                             "non_homogenous_forward_layer_only"
+    }
+
+    ConVars
+    {
+
+        m_rawinput                   "1" // Uses raw mouse input, better aim consistency, no FPS cost
+        cl_input_enable_raw_keyboard "1" // Uses raw keyboard input, slightly lower input latency
+        m_filter                     "0" // Disables mouse smoothing, improves responsiveness
+
+        // -------------Delete this part if you care about lighting --------------------------
+
+        r_directlighting            "0" // Disables direct lighting, large FPS gain
+        r_rendersun                 "0" // Disables sun lighting, reduces GPU load
+        lb_enable_shadow_casting    "0" // Turns off shadow casting, huge FPS boost
+        lb_enable_dynamic_lights    "0" // Disables dynamic lights, fewer draw calls
+        lb_enable_lights            "1" // Disables static lights, saves GPU time
+        lb_enable_stationary_lights "0" // Disables stationary lights, extra lighting savings
+
+        // -----------------------------------------------------------------------------------
+
+        lb_csm_draw_alpha_tested                "0"      // Disables alpha-tested shadows, reduces shadow passes
+        lb_csm_draw_translucent                 "0"      // Disables translucent shadows, saves GPU
+        csm_max_shadow_dist_override            "0"      // Forces shadows to stay disabled
+        sc_disable_spotlight_shadows            "1"      // Disables spotlight shadows, very expensive feature
+        sc_disable_shadow_materials             "1"      // Prevents special shadow materials from rendering
+        cl_globallight_shadow_mode              "0"      // Forces lowest global shadow mode
+        sparseshadowtree_enable_rendering       "0"      // Disables advanced sparse shadow system, big performance saver
+        sparseshadowtree_disable_for_viewmodel  "1"      // Prevents viewmodel from using sparse shadows
+        r_distancefield_enable                  "1"      // Enables distance fields (needed for outlines, low cost)
+        r_citadel_outlines                      "1"      // Enables enemy outlines, improves visibility
+        r_citadel_distancefield_farfield_enable "false"  // Disables long-range distance field effects
+        r_citadel_npr_outlines_max_dist         "600"    // Limits outline distance to reduce unnecessary processing
+        r_enable_volume_fog                     "0"      // Disables volumetric fog, large FPS gain
+        r_enable_gradient_fog                   "0"      // Disables gradient fog, saves GPU
+        r_enable_cubemap_fog                    "0"      // Disables cubemap fog, saves GPU
+        volume_fog_intermediate_textures_hdr    "0"      // Disables HDR fog textures, reduces VRAM usage
+        r_draw3dskybox                          "0"      // Disables 3D skybox, saves GPU time
+        r_monitor_3dskybox                      "0"      // Prevents skybox monitoring updates
+        r_world_wind_strength                   "0"      // Disables wind effects, cosmetic only
+        sv_waterdist                            "0"      // Reduces water rendering distance
+        r_drawparticles                         "1"      // Keeps particles enabled (gameplay readability)
+        r_particle_max_detail_level             "0"      // Lowest particle detail, better FPS
+        r_particle_shadows                      "0"      // Disables particle shadows, high FPS gain
+        r_particle_cables_cast_shadows          "0"      // Disables cable shadows, saves GPU
+        r_RainParticleDensity                   "0"      // Removes rain particles
+        r_physics_particle_op_spawn_scale       "0"      // Prevents physics-based particle spawns
+        r_particle_model_new8                   "0"      // Disables newer particle models, saves performance
+        cl_show_splashes                        "0"      // Disables water splashes, cosmetic only
+        cl_particle_fallback_base               "4"      // Safe particle simplification threshold
+        cl_particle_fallback_multiplier         "4"      // Controls how fast particles fall back to simple versions
+        cloth_update                            "1"      // Keeps cloth enabled for model stability
+        cloth_sim_on_tick                       "1"      // Updates cloth every tick, prevents jitter
+        r_hair_ao                               "0"      // Disables hair ambient occlusion, cosmetic only
+        cl_ragdoll_limit                        "1"      // Limits number of ragdolls, saves CPU
+        ragdoll_parallel_pose_control           "1"      // Multithreaded ragdoll handling, better performance
+        r_character_decal_resolution            "1"      // Low-resolution character decals
+        r_drawmodeldecals                       "0"      // Disables model decals, saves GPU
+        r_decals                                "16"     // Limits number of decals, improves FPS
+        skeleton_instance_lod_optimization      "1"      // Enables model LOD optimization
+        sc_clutter_enable                       "0"      // Disables clutter props, improves visibility & FPS
+        r_size_cull_threshold                   "1.2"    // Aggressive object culling to reduce draw calls
+        r_drawropes                             "0"      // Disables rope rendering
+        rope_collide                            "0"      // Disables rope collision physics
+        rope_subdiv                             "0"      // Disables rope subdivisions
+        rope_wind_dist                          "0"      // Disables rope wind simulation
+        r_ropetranslucent                       "0"      // Disables translucent ropes
+        r_grass_quality                         "0"      // Lowest grass quality
+        r_grass_start_fade                      "0"      // Grass fades immediately
+        r_grass_end_fade                        "0"      // Grass not rendered at distance
+        panorama_disable_box_shadow             "1"      // Disables UI shadows, saves UI render cost
+        panorama_max_overlay_fps                "0"      // Uncaps UI overlay FPS
+        panorama_max_fps                        "0"      // Uncaps UI FPS
+        rate                                    "786432" // Max network bandwidth allowed
+        cl_predict                              "1"      // Enables client-side prediction
+        cl_smooth                               "0"      // Disables view smoothing, reduces input latency
+        mat_colorcorrection                     "1"      // Colour stuff
+
+        // End of piggy's config
+
+        // ================ In Testing ================
+
+        citadel_npc_force_animate_every_tick    "false"
+        citadel_outer_radius_scaler             "0.25"
+        iv_parallel_restore                     "false"
+        panorama_use_new_occlusion_invalidation "false"
+        r_decals_default_fade_duration          "1"
+        r_texture_budget_update_period          "0.5"
+        save_parallel                           "true"
+
+
+        rate
+        {
+            min     "98304"
+            default "786432"
+            max     "1000000"
+        }
+        sv_minrate                   "98304"
+        sv_maxunlag                  "0.500"
+        sv_maxunlag_player           "0.200"
+        sv_lagcomp_filterbyviewangle "false"
+
+        // Spew warning when adding/removing classes to/from the top of the hierarchy
+        panorama_classes_perf_warning_threshold_ms "0.75"
+
+        // Panorama - enable minidumps on JS exceptions
+        panorama_js_minidumps "1"
+        // Enable the render target cache optimization.
+        panorama_disable_render_target_cache "0"
+
+        // Enable the composition layer optimization
+        panorama_skip_composition_layer_content_paint "1"
+
+        // too expensive (500MB+) to load this
+        snd_steamaudio_load_reverb_data  "0"
+        snd_steamaudio_load_pathing_data "0"
+
+        // Steam Audio project specific convars
+        snd_steamaudio_enable_custom_hrtf  "0"
+        snd_steamaudio_active_hrtf         "0"
+        snd_steamaudio_reverb_update_rate  "10.0"
+        snd_steamaudio_ir_duration         "1.0"
+        snd_steamaudio_enable_pathing      "0"
+        snd_steamaudio_invalid_path_length "0.0"
+        cl_disconnect_soundevent           "citadel.convar.stop_all_game_layer_soundevents"
+        snd_event_browser_default_stack    "citadel_default_3d"
+
+        // voip
+        voice_in_process "1"
+
+        // Sound debugging
+        snd_report_audio_nan "1"
+
+        // Audio system settings
+        snd_sos_max_event_base_depth "10"
+        sos_use_guid_filter          "1"
+
+        voice_always_sample_mic
+        {
+            version "2"
+            default "0"
+        }
+
+        reset_voice_on_input_stallout "0"
+        voice_input_stallout          "0.5"
+        cl_usesocketsforloopback      "1"
+        cl_poll_network_early         "0"
+
+        // For perf reasons, since we don't use source-based DSP:
+        disable_source_soundscape_trace "1"
+
+        // Networking - Induced latency (pred offset)
+        cl_tickpacket_recvmargin_desired              "5"   // 5 ms base, min. floor for protecting against thrashing the queue
+        cl_tickpacket_desired_queuelength             "0"   // 0 = attempt to always reach the queue's min floor
+        cl_async_usercmd_send_disabled_recvmargin_min "0.5" // Additional frame since we do not use the async usercmd send (potentially unneccessary)
+        cl_clock_buffer_ticks                         "1"
+        cl_interp_ratio                               "0"
+        cl_async_usercmd_send                         "false"
+
+        fps_max    "400"
+        fps_max_ui "120"
+
+        in_button_double_press_window "0.3"
+
+        // Convars that control spatialization of UI audio.
+        snd_ui_positional            "1"
+        snd_ui_spatialization_spread "2.4"
+
+        // sound volume rate change limiting
+        snd_envelope_rate                        "100.0"
+        snd_soundmixer_update_maximum_frame_rate "0"
+
+        //don't let people mess with speaker config settings.
+        speaker_config
+        {
+            min     "0"
+            default "0"
+            max     "2"
+        }
+
+        cq_buffer_bloat_msecs_max "120"
+
+        snd_soundmixer                   "Default_Mix"
+        cloth_filter_transform_stateless "0"
+
+        cl_joystick_enabled       "0"
+        panorama_joystick_enabled "0"
+
+        snd_event_browser_focus_events "true"
+
+        cl_max_particle_pvs_aabb_edge_length "100"
+
+        // Allow aggregation of particles (for perf)
+        cl_aggregate_particles "true"
+
+        citadel_enable_vdata_sound_preload "true"
+    }
+
+    Memory
+    {
+        EstimatedMaxCPUMemUsageMB "1"
+        EstimatedMinGPUMemUsageMB "1"
+
+        ShowInsufficientPageFileMessageBox      "1"
+        ShowLowAvailableVirtualMemoryMessageBox "1"
+    }
 }
-
-
-

--- a/test_cfg/gameinfo.gi
+++ b/test_cfg/gameinfo.gi
@@ -1,1 +1,1 @@
-Unused for now :D
+Unused "for now :D"


### PR DESCRIPTION
`vdf-fmt` is getting ready for a public release. it is written in rust.

- remove erroneous whitespaces
- normalize grouped key/value pair spacing
- justify comments
- normalize indentation
- remove quotes when possible on key names
- reflow commented out key/value pairs too; require single space after comment
- force quotes on all values (yeah I went back to this on that because it makes it easier to edit if you know where the value "starts")

let me know if any of these formatting choices should be changed.